### PR TITLE
Minor cosmetic change to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-<p style="text-align:center;">
+<p align="center" style="text-align:center;">
     <img alt="pyDVL Logo" src="https://raw.githubusercontent.com/appliedAI-Initiative/pyDVL/develop/logo.svg" width="200"/>
 </p>
 
-<p style="text-align:center;">
+<p align="center" style="text-align:center;">
     A library for data valuation.
 </p>
 
-<p style="text-align:center;">
+<p align="center" style="text-align:center;">
     <a href="https://github.com/appliedAI-Initiative/pyDVL/actions/workflows/tox.yaml">
         <img src="https://github.com/appliedAI-Initiative/pyDVL/actions/workflows/tox.yaml/badge.svg" alt="Build Status"/>
     </a>
 </p>
 
-<p style="text-align:center;">
+<p align="center" style="text-align:center;">
     <strong>
     <a href="https://appliedAI-Initiative.github.io/pyDVL">Docs</a>
     </strong>


### PR DESCRIPTION
This PR puts back the `align="center"` style to the paragraph elements of the readme.