### PR TITLE
Improve adding Notebooks to the Documentation

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -64,9 +64,7 @@ jobs:
         key: tox-${{ github.ref }}-${{ runner.os }}-${{ hashFiles('tox.ini') }}
         path: .tox
     - name: Build Docs
-      run: |
-        cp notebooks/*.ipynb docs/examples/
-        tox -e docs
+      run: tox -e docs
     - name: Save built docs
       uses: actions/upload-artifact@v3
       with:

--- a/docs/_ext/copy_notebooks.py
+++ b/docs/_ext/copy_notebooks.py
@@ -1,16 +1,15 @@
 import os
 import shutil
 from pathlib import Path
-from typing import List
 
 from sphinx.application import Sphinx
-from sphinx.environment import BuildEnvironment
+from sphinx.config import Config
 from sphinx.util import logging
 
 logger = logging.getLogger(__name__)
 
 
-def copy_notebooks(app: Sphinx, env: BuildEnvironment, docnames: List[str]) -> None:
+def copy_notebooks(app: Sphinx, config: Config) -> None:
     logger.info("Copying notebooks to examples directory")
     root_dir = Path(app.confdir).parent
     notebooks_dir = root_dir / "notebooks"
@@ -22,9 +21,9 @@ def copy_notebooks(app: Sphinx, env: BuildEnvironment, docnames: List[str]) -> N
         logger.info(
             f"Copying '{os.fspath(notebook)}' to '{os.fspath(target_filepath)}'"
         )
-        shutil.copy(src=notebook, dst=target_filepath)
+        shutil.copyfile(src=notebook, dst=target_filepath)
     logger.info("Finished copying notebooks to examples directory")
 
 
 def setup(app):
-    app.connect("env-before-read-docs", copy_notebooks)
+    app.connect("config-inited", copy_notebooks)

--- a/docs/_ext/copy_notebooks.py
+++ b/docs/_ext/copy_notebooks.py
@@ -1,0 +1,25 @@
+import shutil
+from pathlib import Path
+from typing import List
+
+from sphinx.application import Sphinx
+from sphinx.environment import BuildEnvironment
+from sphinx.util import logging
+
+logger = logging.getLogger(__name__)
+
+
+def copy_notebooks(app: Sphinx, env: BuildEnvironment, docnames: List[str]) -> None:
+    logger.info("Copying notebooks to examples directory")
+    root_dir = Path(app.confdir).parent
+    notebooks_dir = root_dir / "notebooks"
+    docs_examples_dir = root_dir / "docs" / "examples"
+    notebook_filepaths = list(notebooks_dir.glob("*.ipynb"))
+    logger.info(f"Found following notebooks: {notebook_filepaths}")
+    for notebook in notebook_filepaths:
+        shutil.copy(src=notebook, dst=docs_examples_dir)
+    logger.info("Finished copying notebooks to examples directory")
+
+
+def setup(app):
+    app.connect("env-before-read-docs", copy_notebooks)

--- a/docs/_ext/copy_notebooks.py
+++ b/docs/_ext/copy_notebooks.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from pathlib import Path
 from typing import List
@@ -17,7 +18,11 @@ def copy_notebooks(app: Sphinx, env: BuildEnvironment, docnames: List[str]) -> N
     notebook_filepaths = list(notebooks_dir.glob("*.ipynb"))
     logger.info(f"Found following notebooks: {notebook_filepaths}")
     for notebook in notebook_filepaths:
-        shutil.copy(src=notebook, dst=docs_examples_dir)
+        target_filepath = docs_examples_dir / notebook.name
+        logger.info(
+            f"Copying '{os.fspath(notebook)}' to '{os.fspath(target_filepath)}'"
+        )
+        shutil.copy(src=notebook, dst=target_filepath)
     logger.info("Finished copying notebooks to examples directory")
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,9 @@ ROOT_DIR = Path(__file__).resolve().parent.parent
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.fspath(ROOT_DIR / "src"))
 
+# For custom extensions
+sys.path.append(os.path.abspath("_ext"))
+
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -42,6 +45,8 @@ extensions = [
     "nbsphinx",
     # see https://github.com/spatialaudio/nbsphinx/issues/24 for an explanation why this extension is necessary
     "IPython.sphinxext.ipython_console_highlighting",
+    # Custom extensions
+    "copy_notebooks",
 ]
 
 # NBSphinx

--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,7 @@ extras =
 description = This is a development environment for the docs that supports hot-reloading of the docs
 commands =
     python build_scripts/update_docs.py
-    sphinx-autobuild -W -b html -d "{envtmpdir}/doctrees" docs "docs/_build/html"
+    sphinx-autobuild -W -b html -d "{envtmpdir}/doctrees" docs "docs/_build/html" --ignore "*.ipynb"
 deps =
     {[testenv:docs]deps}
     sphinx-autobuild


### PR DESCRIPTION
This PR changes the way we add notebooks to the documentation.

It adds a custom extension that hooks into the `env-before-read-docs` sphinx build event and copies the notebooks before the docs' source files are read.