### PR TITLE
Fix preview release creation in CI

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,7 +5,7 @@ tag = False
 allow_dirty = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
-	{major}.{minor}.{patch}-{release}{build}
+	{major}.{minor}.{patch}.{release}{build}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,9 @@
 [bumpversion]
-current_version = 0.1.1-dev0
+current_version = 0.1.1.dev0
 commit = False
 tag = False
 allow_dirty = False
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}
 	{major}.{minor}.{patch}

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -134,6 +134,6 @@ jobs:
         run: |
           set -x
           export CURRENT_VERSION=$(python setup.py --version)
-          export BUILD_NUMBER=${{ env.GITHUB_RUN_NUMBER }}
+          export BUILD_NUMBER=$GITHUB_RUN_NUMBER
           tox -e bump-dev-version
           tox -e publish-test-package

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -127,10 +127,10 @@ jobs:
           user_name: ${{ env.GITHUB_BOT_USERNAME }}
           user_email: ${{ env.GITHUB_BOT_EMAIL }}
       - name: Build and publish to TestPyPI
-        # if: ${{ github.ref == 'refs/heads/develop' }}
+        if: ${{ github.ref == 'refs/heads/develop' }}
         env:
           TWINE_USERNAME: __token__
-          # TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
         run: |
           set -x
           export CURRENT_VERSION=$(python setup.py --version)

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -132,9 +132,8 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
         run: |
-          git config user.name "${{ env.GITHUB_BOT_USERNAME }}"
-          git config user.email "${{ env.GITHUB_BOT_EMAIL }}"
-          tox -e bump-dev-version-and-create-tag
-          git push
-          git push --tags
+          set -x
+          export CURRENT_VERSION=$(python setup.py --version)
+          export BUILD_NUMBER=${{ env.GITHUB_RUN_NUMBER }}
+          tox -e bump-dev-version
           tox -e publish-test-package

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -1,4 +1,4 @@
-name: Run tests, build docs, release to TestPyPI
+name: Run tests, build docs, publish to TestPyPI
 
 on:
   push:
@@ -127,10 +127,10 @@ jobs:
           user_name: ${{ env.GITHUB_BOT_USERNAME }}
           user_email: ${{ env.GITHUB_BOT_EMAIL }}
       - name: Build and publish to TestPyPI
-        if: ${{ github.ref == 'refs/heads/develop' }}
+        # if: ${{ github.ref == 'refs/heads/develop' }}
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+          # TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
         run: |
           set -x
           export CURRENT_VERSION=$(python setup.py --version)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     include_package_data=True,
-    version="0.1.1-dev0",
+    version="0.1.1.dev0",
     description="The Python Data Valuation Library",
     install_requires=[
         line

--- a/src/pydvl/__init__.py
+++ b/src/pydvl/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.1-dev0"
+__version__ = "0.1.1.dev0"

--- a/tox.ini
+++ b/tox.ini
@@ -125,7 +125,7 @@ deps =
     twine
 commands =
     python setup.py sdist bdist_wheel
-    # twine upload -r testpypi --verbose --non-interactive dist/*
+    twine upload -r testpypi --verbose --non-interactive dist/*
 
 [testenv:publish-release-package]
 description = Publish package to PyPI

--- a/tox.ini
+++ b/tox.ini
@@ -125,7 +125,7 @@ deps =
     twine
 commands =
     python setup.py sdist bdist_wheel
-    twine upload -r testpypi --verbose --non-interactive dist/*
+    # twine upload -r testpypi --verbose --non-interactive dist/*
 
 [testenv:publish-release-package]
 description = Publish package to PyPI

--- a/tox.ini
+++ b/tox.ini
@@ -139,10 +139,12 @@ commands =
     twine upload --verbose --non-interactive dist/*
 
 
-[testenv:bump-dev-version-and-create-tag]
-description = Bumps the build part of the version and creates new tag for it
+[testenv:bump-dev-version]
+description = Bumps the build part of the version using the given number
 skip_install = true
+passenv =
+    BUILD_NUMBER
 deps =
     bump2version
 commands =
-    bump2version --tag --commit --verbose {posargs:build}
+    bump2version --no-tag --no-commit --verbose --serialize '\{major\}.\{minor\}.\{patch\}.\{release\}\{$BUILD_NUMBER\}' boguspart


### PR DESCRIPTION
This PR clses issue #154 .

It modifies the publishing of preview packages to TestPyPI from CI in order for it to easily work with Gitub's branch protection.