### PR TITLE
Add more badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@
     <a href="https://github.com/appliedAI-Initiative/pyDVL/actions/workflows/tox.yaml">
         <img src="https://github.com/appliedAI-Initiative/pyDVL/actions/workflows/tox.yaml/badge.svg" alt="Build Status"/>
     </a>
+    <br>
+    <a href="https://pypi.org/project/pydvl/">
+        <img src="https://img.shields.io/pypi/v/pydvl.svg"/>
+    </a>
+    <a href="https://pypi.org/project/pydvl/">
+        <img src="https://img.shields.io/pypi/pyversions/pydvl.svg"/>
+    </a>
+    <img alt="PyPI - License" src="https://img.shields.io/pypi/l/pydvl"/>
 </p>
 
 <p align="center" style="text-align:center;">


### PR DESCRIPTION
This PR adds more badges (latest version on pypi, supported python version, license) to the readme. 

Here's what the badges look like:

![image](https://user-images.githubusercontent.com/27914730/195389929-64d235ff-2b80-4582-a591-f1077e4010e6.png)
