### PR TITLE
Fix powerset sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Simplified and fixed powerset sampling
+- Simplified and fixed powerset sampling and testing
   [PR #181](https://github.com/appliedAI-Initiative/pyDVL/pull/181)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Simplified and fixed powerset sampling
+  [PR #181](https://github.com/appliedAI-Initiative/pyDVL/pull/181)
+
+
 ## 0.2.0 - 📚 Better docs
 
 Mostly API documentation and notebooks, plus some bugfixes.

--- a/src/pydvl/shapley/montecarlo.py
+++ b/src/pydvl/shapley/montecarlo.py
@@ -43,10 +43,7 @@ import numpy as np
 from ..reporting.scores import sort_values
 from ..utils import Utility, maybe_progress
 from ..utils.config import ParallelConfig
-from ..utils.numeric import (
-    get_running_avg_variance,
-    random_powerset,
-)
+from ..utils.numeric import get_running_avg_variance, random_powerset
 from ..utils.parallel import MapReduceJob, init_parallel_backend
 from .actor import get_shapley_coordinator, get_shapley_worker
 

--- a/src/pydvl/shapley/montecarlo.py
+++ b/src/pydvl/shapley/montecarlo.py
@@ -44,7 +44,6 @@ from ..reporting.scores import sort_values
 from ..utils import Utility, maybe_progress
 from ..utils.config import ParallelConfig
 from ..utils.numeric import (
-    PowerSetDistribution,
     get_running_avg_variance,
     random_powerset,
 )
@@ -235,7 +234,6 @@ def _combinatorial_montecarlo_shapley(
     indices: Sequence[int],
     u: Utility,
     max_iterations: int,
-    dist: PowerSetDistribution,
     *,
     progress: bool = False,
     job_id: int = 1,
@@ -248,7 +246,6 @@ def _combinatorial_montecarlo_shapley(
 
     :param u: Utility object with model, data, and scoring function
     :param max_iterations: total number of subsets to sample.
-    :param dist: Distribution to use of sets over the power set.
     :param progress: true to plot progress bar
     :param job_id: id to use for reporting progress
     :return: A tuple of ndarrays with estimated values and standard errors
@@ -258,13 +255,10 @@ def _combinatorial_montecarlo_shapley(
     if len(np.unique(indices)) != len(indices):
         raise ValueError("Repeated indices passed")
 
-    # FIXME: is this ok?
-    if dist is PowerSetDistribution.WEIGHTED:
-        correction = 2 ** (n - 1) / n
-    else:
-        raise NotImplementedError(
-            f"Correction for sampling distribution {dist=} not implemented"
-        )
+    # Correction coming from Monte Carlo integration: the uniform distribution
+    # over the powerset of a set with n-1 elements has mass 2^{n-1} over each
+    # subset. The additional factor n is from the averaging.
+    correction = 2 ** (n - 1) / n
 
     values = np.zeros(n)
     variances = np.zeros(n)
@@ -273,11 +267,7 @@ def _combinatorial_montecarlo_shapley(
     for idx in pbar:
         # Randomly sample subsets of full dataset without idx
         subset = np.setxor1d(u.data.indices, [idx], assume_unique=True)
-        power_set = random_powerset(
-            subset,
-            dist=dist,
-            max_subsets=max_iterations,
-        )
+        power_set = random_powerset(subset, max_subsets=max_iterations)
         for s in maybe_progress(
             power_set,
             progress,
@@ -305,7 +295,6 @@ def combinatorial_montecarlo_shapley(
     n_jobs: int = 1,
     config: ParallelConfig = ParallelConfig(),
     *,
-    dist: PowerSetDistribution = PowerSetDistribution.WEIGHTED,
     progress: bool = False,
 ) -> Tuple["OrderedDict[str, float]", Dict[str, float]]:
     """Computes an approximate Shapley value using the combinatorial definition.
@@ -315,7 +304,6 @@ def combinatorial_montecarlo_shapley(
     :param n_jobs: number of jobs across which to distribute the computation
     :param config: Object configuring parallel computation, with cluster
         address, number of cpus, etc.
-    :param dist: Distribution to use of sets over the power set.
     :param progress: true to plot progress bar
     :return: Tuple with the first element being an ordered Dict of approximate
         Shapley values for the indices, the second being their standard error
@@ -340,7 +328,6 @@ def combinatorial_montecarlo_shapley(
         reduce_func=reducer,
         map_kwargs=dict(
             u=u_id,
-            dist=dist,
             max_iterations=max_iterations,
             progress=progress,
         ),


### PR DESCRIPTION
This pr undoes all the weird shit I did to sample from a powerset (wtf was all that about??)  and changes the test to do something more natural to me, which is to check the frequencies at which elements (roughly 2**-n) and at which subset sizes (roughly comb(n,k) appear.

I also removed the distribution parameter because it was not being used and all MC sums use a uniform distribution. I know we have #121 but I think we can add any arguments / methods / classes later if needed.