### PR TITLE
Fix and simplify release process

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,9 @@
 name: Upload Python Package to PyPI
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+    - "v*"
 
 env:
   PY_COLORS: 1
@@ -16,6 +17,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Fail if not on master branch
+        if: github.ref != 'refs/heads/master'
+        run: exit -1
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
This PR attempts to fix and simplify the release process.

It changes the the workflow that publishes packages to PyPI to only trigger on tags on the master branch.