### PR TITLE
Make pull request template link PR to issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ https://github.com/appliedAI-Initiative/pyDVL/blob/develop/CONTRIBUTING.md
 
 ### Description
 
-This PR closes issue #XXX
+This PR closes #XXX
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   [PR #184](https://github.com/appliedAI-Initiative/pyDVL/pull/184)
 - Added Pull Request template
   [PR #185](https://github.com/appliedAI-Initiative/pyDVL/pull/185)
+- Modified Pull Request template to automatically link PR to issue
+  [PR ##186](https://github.com/appliedAI-Initiative/pyDVL/pull/186)
 
 
 ## 0.2.0 - 📚 Better docs


### PR DESCRIPTION
### Description

This PR closes #174 (again).

It makes a slight modification to the PR template to automatically link a PR to an issue so that the latter is closed when the former is merged.

### Checklist

- [ ] ~Wrote Unit tests (if necessary)~
- [ ] ~Updated Documentation (if necessary)~
- [X] Updated Changelog
- [ ] ~If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`~
