### PR TITLE
Support python versions from 3.8 to 3.10

### DIFF
--- a/.github/workflows/run-tests-workflow.yaml
+++ b/.github/workflows/run-tests-workflow.yaml
@@ -4,9 +4,13 @@ on:
   workflow_call:
     inputs:
       tests_to_run:
-        description: "Determines which tests to run using Tox. Should be one of: default, torch, notebooks"
+        description: "Determines which tests to run using Tox. Should be one of: base, torch, notebooks"
         type: string
-        required: false
+        required: true
+      python_version:
+        description: "Determines which Python version to use"
+        type: string
+        required: true
 
 env:
   PY_COLORS: 1
@@ -18,10 +22,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up Python 3.8
+    - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: ${{ inputs.python-version }}
         cache: 'pip'
     - name: Install Dev Requirements
       run: pip install -r requirements-dev.txt

--- a/.github/workflows/run-tests-workflow.yaml
+++ b/.github/workflows/run-tests-workflow.yaml
@@ -22,10 +22,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up Python ${{ inputs.python-version }}
+    - name: Set up Python ${{ inputs.python_version }}
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ inputs.python-version }}
+        python-version: ${{ inputs.python_version }}
         cache: 'pip'
     - name: Install Dev Requirements
       run: pip install -r requirements-dev.txt

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -71,22 +71,34 @@ jobs:
         path: ./docs/_build
         retention-days: 1
   base-tests:
+    strategy:
+      matrix:
+        python_version: ["3.8", "3.9", "3.10"]
     name: Run base tests
     uses: ./.github/workflows/run-tests-workflow.yaml
     with:
       tests_to_run: base
+      python_version: ${{ matrix.python_version }}
     needs: [lint]
   torch-tests:
+    strategy:
+      matrix:
+        python_version: ["3.8", "3.9", "3.10"]
     name: Run tests that use PyTorch
     uses: ./.github/workflows/run-tests-workflow.yaml
     with:
       tests_to_run: torch
+      python_version: ${{ matrix.python_version }}
     needs: [lint]
   notebook-tests:
+    strategy:
+      matrix:
+        python_version: ["3.8", "3.9", "3.10"]
     name: Run notebook tests
     uses: ./.github/workflows/run-tests-workflow.yaml
     with:
       tests_to_run: notebooks
+      python_version: ${{ matrix.python_version }}
     needs: [lint]
   push-docs-and-release-testpypi:
     name: Push Docs and maybe release Package to TestPyPI

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -2,7 +2,7 @@ name: Run tests, build docs, publish to TestPyPI
 
 on:
   push:
-    branches: [develop, main]
+    branches: [develop, master]
   pull_request:
     branches: [develop]
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - GH action to mark issues as stale
   [PR #201](https://github.com/appliedAI-Initiative/pyDVL/pull/201)
+- Test and officially support Python version 3.9 and 3.10 
+  [PR #208](https://github.com/appliedAI-Initiative/pyDVL/pull/208)
 
 ## 0.3.0 - 💥 Breaking changes
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ setup(
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Typing :: Typed",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: Microsoft :: Windows",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = base, report
 wheel = true
 
 [testenv]
-basepython = python3.8
 deps =
     pytest
     pytest-cov


### PR DESCRIPTION
### Description

This PR closes #53

### Changes

- It removes the `basepython` configuration field from the tox.ini file.
- It adds a matrix strategy to test multiple python versions in CI.
- Added classifiers for the new python versions in setup.py.

### Checklist

- [x] ~Wrote Unit tests (if necessary)~
- [x] ~Updated Documentation (if necessary)~
- [x] Updated Changelog
- [x] ~If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`~
