### PR TITLE
Fix using remote ray actor with external cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - **Bug fix**: Fixes bug in Truncated Monte Carlo Shapley (TMC) method
   when using a remote Ray cluster,
   raises an error if a user attempts to use TMC with the dummy sequential
-  parallel backend
+  parallel backend,
+  catch all warnings in Utility when show_warnings is set to False
   [PR #247](https://github.com/appliedAI-Initiative/pyDVL/pull/247)
 
 ## 0.4.0 - 🏭💥 New algorithms and more breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   Truncated Monte Carlo Shapley (TMC) method  when using a remote Ray cluster,
   raises an error if a user attempts to use TMC with the dummy sequential
   parallel backend,
-  clone model inside Utility before fitting and scoring it,
+  clone model inside Utility before fitting and scoring it by default
+  and add boolean `clone_before_fit` argument to disable it if needed,
   catch all warnings in Utility when show_warnings is set to False,
   Add Miner and Gloves toy games utilities
   [PR #247](https://github.com/appliedAI-Initiative/pyDVL/pull/247)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- **Bug fix**: Fixes bug in Truncated Monte Carlo Shapley (TMC) method
+  when using a remote Ray cluster,
+  raises an error if a user attempts to use TMC with the dummy sequential
+  parallel backend
+  [PR #247](https://github.com/appliedAI-Initiative/pyDVL/pull/247)
+
 ## 0.4.0 - 🏭💥 New algorithms and more breaking changes
 
 - GH action to mark issues as stale

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Unreleased
 
-- **Bug fix**: Fixes bug in Truncated Monte Carlo Shapley (TMC) method
-  when using a remote Ray cluster,
+- **Bug fix and minor imporvements**: Fixes bug in
+  Truncated Monte Carlo Shapley (TMC) method  when using a remote Ray cluster,
   raises an error if a user attempts to use TMC with the dummy sequential
   parallel backend,
-  catch all warnings in Utility when show_warnings is set to False
+  clone model inside Utility before fitting and scoring it,
+  catch all warnings in Utility when show_warnings is set to False,
+  Add Miner and Gloves toy games utilities
   [PR #247](https://github.com/appliedAI-Initiative/pyDVL/pull/247)
 
 ## 0.4.0 - 🏭💥 New algorithms and more breaking changes

--- a/src/pydvl/utils/parallel/actor.py
+++ b/src/pydvl/utils/parallel/actor.py
@@ -1,11 +1,10 @@
 import abc
 import inspect
 import logging
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Type, Union, cast
 
-from ray import ObjectRef
-
-from .backend import RayParallelBackend
+from pydvl.utils.config import ParallelConfig
+from pydvl.utils.parallel.backend import RayParallelBackend, init_parallel_backend
 
 __all__ = ["RayActorWrapper", "Coordinator", "Worker"]
 
@@ -42,8 +41,10 @@ class RayActorWrapper:
     5
     """
 
-    def __init__(self, actor_handle: ObjectRef, parallel_backend: RayParallelBackend):
-        self.actor_handle = actor_handle
+    def __init__(self, actor_class: Type, config: ParallelConfig, *args, **kwargs):
+        parallel_backend = cast(RayParallelBackend, init_parallel_backend(config))
+        remote_cls = parallel_backend.wrap(actor_class)
+        self.actor_handle = remote_cls.remote(*args, **kwargs)
 
         def remote_caller(method_name: str):
             # Wrapper for remote class' methods to mimic local calls
@@ -62,7 +63,7 @@ class RayActorWrapper:
 
             return wrapper
 
-        for member in inspect.getmembers(self.actor_handle):
+        for member in inspect.getmembers(actor_class):
             name = member[0]
             if not name.startswith("__"):
                 # Wrap public methods for remote-as-local calls.

--- a/src/pydvl/utils/parallel/actor.py
+++ b/src/pydvl/utils/parallel/actor.py
@@ -31,12 +31,7 @@ class RayActorWrapper:
     ...         return self.x
     ...
     >>> config = ParallelConfig(backend="ray")
-    >>> parallel_backend = init_parallel_backend(config)
-    >>> assert isinstance(parallel_backend, RayParallelBackend)
-    >>> actor_handle = parallel_backend.wrap(Actor).remote(5)
-    >>> parallel_backend.get(actor_handle.get.remote())
-    5
-    >>> wrapped_actor = RayActorWrapper(actor_handle, parallel_backend)
+    >>> wrapped_actor = RayActorWrapper(Actor, config, 5)
     >>> wrapped_actor.get()
     5
     """

--- a/src/pydvl/utils/parallel/backend.py
+++ b/src/pydvl/utils/parallel/backend.py
@@ -1,5 +1,4 @@
 import functools
-import logging
 import os
 from abc import ABCMeta, abstractmethod
 from dataclasses import asdict

--- a/src/pydvl/utils/parallel/backend.py
+++ b/src/pydvl/utils/parallel/backend.py
@@ -112,14 +112,7 @@ class SequentialParallelBackend(BaseParallelBackend, backend_name="sequential"):
         return v, []
 
     def _effective_n_jobs(self, n_jobs: int) -> int:
-        if n_jobs < 0:
-            if self.config["num_cpus"]:
-                eff_n_jobs: int = self.config["num_cpus"]
-            else:
-                eff_n_jobs = available_cpus()
-        else:
-            eff_n_jobs = n_jobs
-        return eff_n_jobs
+        return 1
 
 
 class RayParallelBackend(BaseParallelBackend, backend_name="ray"):

--- a/src/pydvl/utils/utility.py
+++ b/src/pydvl/utils/utility.py
@@ -267,14 +267,15 @@ class MinerUtility(Utility):
 
     Consider a group of n miners, who have discovered large bars of gold.
 
-    If two miners can carry one piece of gold, then the payoff of a coalition S is:
+    If two miners can carry one piece of gold,
+    then the payoff of a coalition $S$ is:
 
-    $$
-    v(S) = \left\{\begin{matrix}
-        |S|/2 & \text{, if} & |S| \text{ is even} \\
-        (|S| - 1)/2 & \text{, if} & |S| \text{ is odd}
-    \end{matrix}\right.
-    $$
+    $${
+    v(S) = \left\{\begin{array}{lll}
+    | S | / 2 & \text{, if} & | S | \text{ is even} \\
+    ( | S | - 1)/2 & \text{, if} & | S |  \text{ is odd}
+    \end{array}\right.
+    }$$
 
     If there are more than two miners and there is an even number of miners,
     then the core consists of the single payoff where each miner gets 1/2.

--- a/src/pydvl/utils/utility.py
+++ b/src/pydvl/utils/utility.py
@@ -41,9 +41,19 @@ class Utility:
     the computation of :ref:`Shapley values<Shapley>` and
     :ref:`Least Core values<Least Core>`.
 
-    Since evaluating the scoring function requires retraining the model, this
-    class wraps it and caches the results of each execution. Caching is
-    available both locally and across nodes, but must always be enabled for your
+    The Utility expect the model to fulfill
+    the :class:`pydvl.utils.types.SupervisedModel` interface
+    i.e. to have a `fit()`, `predict()`, and `score()` methods.
+
+    When calling the utility, the model will be
+    `cloned <https://scikit-learn.org/stable/modules/generated/sklearn.base.clone.html>`_
+    if it is a Sci-Kit Learn model, otherwise a copy is created using `deepcopy()`
+    from the builtin `copy <https://docs.python.org/3/library/copy.html>`_ module.
+
+    Since evaluating the scoring function requires retraining the model
+    and that can be time consuming, this class wraps it and caches
+    the results of each execution. Caching is available both locally
+    and across nodes, but must always be enabled for your
     project first, see :ref:`how to set up the cache<caching setup>`.
 
     :param model: Any supervised model. Typical choices can be found at
@@ -129,8 +139,9 @@ class Utility:
         return utility
 
     def _utility(self, indices: FrozenSet) -> float:
-        """Fits the model on a subset of the training data and scores it on the
-        test data. If the object is constructed with `enable_cache = True`,
+        """Clones the model, fits it on a subset of the training data
+        and scores it on the test data.
+        If the object is constructed with `enable_cache = True`,
         results are memoized to avoid duplicate computation. This is useful in
         particular when computing utilities of permutations of indices or when
         randomly sampling from the powerset of indices.

--- a/src/pydvl/utils/utility.py
+++ b/src/pydvl/utils/utility.py
@@ -371,13 +371,11 @@ class GlovesGameUtility(Utility):
         pass
 
     def exact_least_core_values(self) -> Tuple[NDArray[np.float_], float]:
+        subsidy = 0.0
         if self.left == self.right:
             values = np.array([0.5] * (self.left + self.right))
-            subsidy = 0.0
         elif self.left < self.right:
             values = np.array([1.0] * self.left + [0.0] * self.right)
-            subsidy = 0.0
         else:
             values = np.array([0.0] * self.left + [1.0] * self.right)
-            subsidy = 0.0
         return values, subsidy

--- a/src/pydvl/utils/utility.py
+++ b/src/pydvl/utils/utility.py
@@ -20,6 +20,7 @@ from typing import Dict, FrozenSet, Iterable, Optional, Tuple, Union
 
 import numpy as np
 from numpy.typing import NDArray
+from sklearn.base import clone
 from sklearn.metrics import check_scoring
 
 from pydvl.utils import Dataset
@@ -152,8 +153,11 @@ class Utility:
             if not self.show_warnings:
                 warnings.simplefilter("ignore")
             try:
-                self.model.fit(x_train, y_train)
-                score = float(self.scorer(self.model, x_test, y_test))
+                # Clone the model to avoid the possibility
+                # of reusing a fitted estimator
+                model = clone(self.model)
+                model.fit(x_train, y_train)
+                score = float(self.scorer(model, x_test, y_test))
                 # Some scorers raise exceptions if they return NaNs, some might not
                 if np.isnan(score):
                     warnings.warn("Scorer returned NaN", RuntimeWarning)

--- a/src/pydvl/utils/utility.py
+++ b/src/pydvl/utils/utility.py
@@ -108,7 +108,7 @@ class Utility:
         cache_options: Optional[MemcachedConfig] = None,
         clone_model: bool = True,
     ):
-        self.model = model
+        self.model = self._clone_model(model)
         self.data = data
         self.default_score = default_score
         # TODO: auto-fill from known scorers ?

--- a/src/pydvl/utils/utility.py
+++ b/src/pydvl/utils/utility.py
@@ -19,10 +19,10 @@ import numpy as np
 from numpy.typing import NDArray
 from sklearn.metrics import check_scoring
 
-from .caching import CacheStats, memcached, serialize
-from .config import MemcachedConfig
-from .dataset import Dataset
-from .types import Scorer, SupervisedModel
+from pydvl.utils.caching import CacheStats, memcached, serialize
+from pydvl.utils.config import MemcachedConfig
+from pydvl.utils.dataset import Dataset
+from pydvl.utils.types import Scorer, SupervisedModel
 
 __all__ = ["Utility", "DataUtilityLearning"]
 

--- a/src/pydvl/utils/utility.py
+++ b/src/pydvl/utils/utility.py
@@ -19,12 +19,12 @@ import numpy as np
 from numpy.typing import NDArray
 from sklearn.metrics import check_scoring
 
+from pydvl.utils import Dataset
 from pydvl.utils.caching import CacheStats, memcached, serialize
 from pydvl.utils.config import MemcachedConfig
-from pydvl.utils.dataset import Dataset
 from pydvl.utils.types import Scorer, SupervisedModel
 
-__all__ = ["Utility", "DataUtilityLearning"]
+__all__ = ["Utility", "DataUtilityLearning", "MinerUtility"]
 
 logger = logging.getLogger(__name__)
 
@@ -260,3 +260,60 @@ class DataUtilityLearning:
     def data(self) -> Dataset:
         """Returns the wrapped utility's :class:`~pydvl.utils.dataset.Dataset`."""
         return self.utility.data
+
+
+class MinerUtility(Utility):
+    r"""Toy Utility that is used only for testing purposes.
+
+    Consider a group of n miners, who have discovered large bars of gold.
+
+    If two miners can carry one piece of gold, then the payoff of a coalition S is:
+
+    $$
+    v(S) = \left\{\begin{matrix}
+        |S|/2 & \text{, if} & |S| \text{ is even} \\
+        (|S| - 1)/2 & \text{, if} & |S| \text{ is odd}
+    \end{matrix}\right.
+    $$
+
+    If there are more than two miners and there is an even number of miners,
+    then the core consists of the single payoff where each miner gets 1/2.
+
+    If there is an odd number of miners, then the core is empty.
+
+    Taken from: https://en.wikipedia.org/wiki/Core_(game_theory)
+
+    :param n_miners: Number of miners that participate in the game.
+    """
+
+    def __init__(self, n_miners: int, **kwargs):
+        if n_miners <= 2:
+            raise ValueError(f"n_miners, {n_miners} should be > 2")
+        self.n_miners = n_miners
+
+        x = np.arange(n_miners)[..., np.newaxis]
+        # The y values don't matter here
+        y = np.zeros_like(x)
+
+        self.data = Dataset(x_train=x, y_train=y, x_test=x, y_test=y)
+
+    def __call__(self, indices: Iterable[int]) -> float:
+        n = len(tuple(indices))
+        if n % 2 == 0:
+            return n / 2
+        else:
+            return (n - 1) / 2
+
+    def _initialize_utility_wrapper(self):
+        pass
+
+    def exact_least_core_values(self) -> Tuple[NDArray[np.float_], float]:
+        if self.n_miners % 2 == 0:
+            values = np.array([0.5] * self.n_miners)
+            subsidy = 0.0
+        else:
+            values = np.array(
+                [(self.n_miners - 1) / (2 * self.n_miners)] * self.n_miners
+            )
+            subsidy = (self.n_miners - 1) / (2 * self.n_miners)
+        return values, subsidy

--- a/src/pydvl/utils/utility.py
+++ b/src/pydvl/utils/utility.py
@@ -118,7 +118,7 @@ class Utility:
         self.enable_cache = enable_cache
         self.cache_options: MemcachedConfig = cache_options or MemcachedConfig()
         self.clone_before_fit = clone_before_fit
-        self._signature = serialize((hash(model), hash(data), hash(scoring)))
+        self._signature = serialize((hash(self.model), hash(data), hash(scoring)))
         self.scorer = check_scoring(self.model, scoring)
         self._initialize_utility_wrapper()
 

--- a/src/pydvl/utils/utility.py
+++ b/src/pydvl/utils/utility.py
@@ -37,7 +37,7 @@ class Utility:
     """Convenience wrapper with configurable memoization of the scoring function.
 
     An instance of `Utility` holds the triple of model, dataset and scoring
-    function which determines the value of data points. This is only used for
+    function which determines the value of data points. This is mosly used for
     the computation of :ref:`Shapley values<Shapley>` and
     :ref:`Least Core values<Least Core>`.
 

--- a/src/pydvl/utils/utility.py
+++ b/src/pydvl/utils/utility.py
@@ -76,7 +76,7 @@ class Utility:
     :param show_warnings: True for printing warnings fit fails.
     :param enable_cache: If True, use memcached for memoization.
     :param cache_options: Optional configuration object for memcached.
-    :param clone_model: If True, the model will be cloned before calling `fit()`.
+    :param clone_before_fit: If True, the model will be cloned before calling `fit()`.
 
     :Example:
 
@@ -106,7 +106,7 @@ class Utility:
         show_warnings: bool = False,
         enable_cache: bool = False,
         cache_options: Optional[MemcachedConfig] = None,
-        clone_model: bool = True,
+        clone_before_fit: bool = True,
     ):
         self.model = self._clone_model(model)
         self.data = data
@@ -117,7 +117,7 @@ class Utility:
         self.show_warnings = show_warnings
         self.enable_cache = enable_cache
         self.cache_options: MemcachedConfig = cache_options or MemcachedConfig()
-        self.clone_model = clone_model
+        self.clone_before_fit = clone_before_fit
         self._signature = serialize((hash(model), hash(data), hash(scoring)))
         self.scorer = check_scoring(self.model, scoring)
         self._initialize_utility_wrapper()
@@ -165,7 +165,7 @@ class Utility:
             if not self.show_warnings:
                 warnings.simplefilter("ignore")
             try:
-                if self.clone_model:
+                if self.clone_before_fit:
                     model = self._clone_model(self.model)
                 else:
                     model = self.model

--- a/src/pydvl/utils/utility.py
+++ b/src/pydvl/utils/utility.py
@@ -155,7 +155,12 @@ class Utility:
             try:
                 # Clone the model to avoid the possibility
                 # of reusing a fitted estimator
-                model = clone(self.model)
+                try:
+                    model = clone(self.model)
+                except TypeError:
+                    # This happens if the passed model is not an sklearn model
+                    # In this case, we just make a deepcopy of the model.
+                    model = clone(self.model, safe=False)
                 model.fit(x_train, y_train)
                 score = float(self.scorer(model, x_test, y_test))
                 # Some scorers raise exceptions if they return NaNs, some might not

--- a/src/pydvl/utils/utility.py
+++ b/src/pydvl/utils/utility.py
@@ -185,14 +185,18 @@ class Utility:
     @staticmethod
     def _clone_model(model: SupervisedModel) -> SupervisedModel:
         """Clones the passed model to avoid the possibility
-        of reusing a fitted estimator"""
+        of reusing a fitted estimator
+
+        :param model: Any supervised model. Typical choices can be found at
+            https://scikit-learn.org/stable/supervised_learning.html
+        """
         try:
             model = clone(model)
         except TypeError:
             # This happens if the passed model is not an sklearn model
             # In this case, we just make a deepcopy of the model.
             model = clone(model, safe=False)
-        model = cast(model, SupervisedModel)
+        model = cast(SupervisedModel, model)
         return model
 
     @property

--- a/src/pydvl/value/shapley/actor.py
+++ b/src/pydvl/value/shapley/actor.py
@@ -8,19 +8,16 @@ methods for pyDVL that use parallelization.
 import logging
 import warnings
 from time import time
-from typing import TYPE_CHECKING, Optional, Tuple, Union, cast
+from typing import Optional, Tuple, Union, cast
 
 import numpy as np
+from numpy.typing import NDArray
 
 from pydvl.utils import Utility, get_running_avg_variance, maybe_progress
 from pydvl.utils.config import ParallelConfig
 from pydvl.utils.parallel.actor import Coordinator, RayActorWrapper, Worker
 from pydvl.utils.parallel.backend import RayParallelBackend, init_parallel_backend
 from pydvl.value.results import ValuationStatus
-
-if TYPE_CHECKING:
-    from numpy.typing import NDArray
-
 
 __all__ = ["get_shapley_coordinator", "get_shapley_worker"]
 
@@ -32,11 +29,9 @@ def get_shapley_coordinator(
     *args, config: ParallelConfig = ParallelConfig(), **kwargs
 ) -> "ShapleyCoordinator":
     if config.backend == "ray":
-        parallel_backend = cast(RayParallelBackend, init_parallel_backend(config))
-        remote_cls = parallel_backend.wrap(ShapleyCoordinator)
-        handle = remote_cls.remote(*args, **kwargs)
         coordinator = cast(
-            ShapleyCoordinator, RayActorWrapper(handle, parallel_backend)
+            ShapleyCoordinator,
+            RayActorWrapper(ShapleyCoordinator, config, *args, **kwargs),
         )
     elif config.backend == "sequential":
         coordinator = ShapleyCoordinator(*args, **kwargs)
@@ -49,10 +44,9 @@ def get_shapley_worker(
     *args, config: ParallelConfig = ParallelConfig(), **kwargs
 ) -> "ShapleyWorker":
     if config.backend == "ray":
-        parallel_backend = cast(RayParallelBackend, init_parallel_backend(config))
-        remote_cls = parallel_backend.wrap(ShapleyWorker)
-        handle = remote_cls.remote(*args, **kwargs)
-        worker = cast(ShapleyWorker, RayActorWrapper(handle, parallel_backend))
+        worker = cast(
+            ShapleyWorker, RayActorWrapper(ShapleyWorker, config, *args, **kwargs)
+        )
     elif config.backend == "sequential":
         worker = ShapleyWorker(*args, **kwargs)
     else:

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -97,7 +97,7 @@ def truncated_montecarlo_shapley(
 
     .. warning::
 
-       This function does not work the sequential parallel backend.
+       This function does not work with the sequential parallel backend.
 
     .. todo::
        Implement the original stopping criterion, maybe Robin-Gelman or some

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -95,6 +95,10 @@ def truncated_montecarlo_shapley(
        criterion detailed in
        :meth:`~pydvl.value.shapley.actor.ShapleyCoordinator.check_done`.
 
+    .. warning::
+
+       This function does not work the sequential parallel backend.
+
     .. todo::
        Implement the original stopping criterion, maybe Robin-Gelman or some
        other more principled one.
@@ -122,6 +126,12 @@ def truncated_montecarlo_shapley(
     :return: Object with the data values.
 
     """
+    if config.backend == "sequential":
+        raise NotImplementedError(
+            "Truncated MonteCarlo Shapley does not work with "
+            "the Sequential parallel backend."
+        )
+
     parallel_backend = init_parallel_backend(config)
 
     n_jobs = parallel_backend.effective_n_jobs(n_jobs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ import numpy as np
 import pytest
 import ray
 from pymemcache.client import Client
+from sklearn import datasets
+from sklearn.utils import Bunch
 
 from pydvl.utils import Dataset, MemcachedClientConfig
 from pydvl.utils.parallel.backend import available_cpus
@@ -150,10 +152,8 @@ def memcached_client(memcache_client_config) -> Tuple[Client, MemcachedClientCon
 
 
 @pytest.fixture(scope="function")
-def boston_dataset(num_points, num_features) -> Dataset:
-    from sklearn import datasets
-
-    dataset = datasets.load_boston()
+def housing_dataset(num_points, num_features) -> Dataset:
+    dataset = datasets.fetch_california_housing()
     dataset.data = dataset.data[:num_points, :num_features]
     dataset.feature_names = dataset.feature_names[:num_features]
     dataset.target = dataset.target[:num_points]
@@ -172,8 +172,6 @@ def linear_dataset(a: float, b: float, num_points: int):
 
     :return: Dataset with train/test split. call str() on it to see the parameters
     """
-    from sklearn.utils import Bunch
-
     step = 2 / num_points
     stddev = 0.1
     x = np.arange(-1, 1, step)

--- a/tests/utils/conftest.py
+++ b/tests/utils/conftest.py
@@ -5,7 +5,7 @@ from ray.cluster_utils import Cluster
 from pydvl.utils.config import ParallelConfig
 
 
-@pytest.fixture(scope="session", params=["sequential", "ray-local", "ray-external"])
+@pytest.fixture(scope="module", params=["sequential", "ray-local", "ray-external"])
 def parallel_config(request):
     if request.param == "sequential":
         yield ParallelConfig(backend=request.param)

--- a/tests/utils/test_parallel.py
+++ b/tests/utils/test_parallel.py
@@ -5,7 +5,23 @@ import numpy as np
 import pytest
 
 from pydvl.utils.parallel import MapReduceJob, init_parallel_backend
+from pydvl.utils.parallel.backend import available_cpus
 from pydvl.utils.parallel.map_reduce import _get_value
+
+
+def test_effective_n_jobs(parallel_config):
+    parallel_backend = init_parallel_backend(parallel_config)
+    if parallel_config.backend == "sequential":
+        assert parallel_backend.effective_n_jobs(1) == 1
+        assert parallel_backend.effective_n_jobs(4) == 1
+        assert parallel_backend.effective_n_jobs(-1) == 1
+    else:
+        assert parallel_backend.effective_n_jobs(1) == 1
+        assert parallel_backend.effective_n_jobs(4) == 4
+        if parallel_config.address is None:
+            assert parallel_backend.effective_n_jobs(-1) == available_cpus()
+        else:
+            assert parallel_backend.effective_n_jobs(-1) == 4
 
 
 @pytest.fixture()

--- a/tests/utils/test_utility.py
+++ b/tests/utils/test_utility.py
@@ -1,9 +1,41 @@
 # TODO add more tests!
+import warnings
 
+import numpy as np
 import pytest
 from sklearn.linear_model import LinearRegression
 
 from pydvl.utils import DataUtilityLearning, MemcachedConfig, Utility, powerset
+
+
+@pytest.mark.parametrize("show_warnings", [False, True])
+@pytest.mark.parametrize("num_points, num_features", [(4, 4)])
+def test_utility_show_warnings(housing_dataset, show_warnings, recwarn):
+    class WarningModel:
+        def fit(self, x, y):
+            warnings.warn("Warning model fit")
+            return self
+
+        def predict(self, x):
+            warnings.warn("Warning model predict")
+            return np.zeros_like(x)
+
+        def score(self, x, y):
+            warnings.warn("Warning model score")
+            return 0.0
+
+    utility = Utility(
+        model=WarningModel(),
+        data=housing_dataset,
+        enable_cache=False,
+        show_warnings=show_warnings,
+    )
+    utility([0])
+
+    if show_warnings:
+        assert len(recwarn) >= 1
+    else:
+        assert len(recwarn) == 0
 
 
 # noinspection PyUnresolvedReferences

--- a/tests/utils/test_utility.py
+++ b/tests/utils/test_utility.py
@@ -81,9 +81,12 @@ def test_cache(linear_dataset, memcache_client_config):
 
 
 @pytest.mark.parametrize("a, b, num_points", [(2, 0, 8)])
-def test_different_cache(linear_dataset, memcache_client_config):
+@pytest.mark.parametrize("model_kwargs", [({}, {}), ({}, {"fit_intercept": False})])
+def test_different_cache_signature(
+    linear_dataset, memcache_client_config, model_kwargs
+):
     u1 = Utility(
-        model=LinearRegression(),
+        model=LinearRegression(**model_kwargs[0]),
         data=linear_dataset,
         scoring="r2",
         enable_cache=True,
@@ -92,7 +95,7 @@ def test_different_cache(linear_dataset, memcache_client_config):
         ),
     )
     u2 = Utility(
-        model=LinearRegression(fit_intercept=False),
+        model=LinearRegression(**model_kwargs[1]),
         data=linear_dataset,
         scoring="r2",
         enable_cache=True,
@@ -102,3 +105,5 @@ def test_different_cache(linear_dataset, memcache_client_config):
     )
 
     assert u1.signature != u2.signature
+    assert u1.signature == u1.signature
+    assert u2.signature == u2.signature

--- a/tests/value/conftest.py
+++ b/tests/value/conftest.py
@@ -67,7 +67,12 @@ def dummy_utility(num_samples):
             return self.utility
 
     return Utility(
-        DummyModel(data), data, score_range=(0, x.sum() / x.max()), enable_cache=False
+        DummyModel(data),
+        data,
+        score_range=(0, x.sum() / x.max()),
+        catch_errors=False,
+        show_warnings=True,
+        enable_cache=False,
     )
 
 

--- a/tests/value/conftest.py
+++ b/tests/value/conftest.py
@@ -1,11 +1,14 @@
 import numpy as np
 import pytest
+import ray
 from numpy.typing import NDArray
+from ray.cluster_utils import Cluster
 from sklearn.linear_model import LinearRegression
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import PolynomialFeatures
 
 from pydvl.utils import Dataset, SupervisedModel, Utility
+from pydvl.utils.config import ParallelConfig
 from pydvl.value import ValuationResult, ValuationStatus
 
 from . import polynomial
@@ -82,3 +85,24 @@ def analytic_shapley(dummy_utility):
         status=ValuationStatus.Converged,
     )
     return dummy_utility, result
+
+
+@pytest.fixture(scope="module", params=["sequential", "ray-local", "ray-external"])
+def parallel_config(request):
+    if request.param == "sequential":
+        pytest.skip("Skipping 'sequential' because it doesn't work with TMC")
+        yield ParallelConfig(backend=request.param)
+    elif request.param == "ray-local":
+        yield ParallelConfig(backend="ray")
+        ray.shutdown()
+    elif request.param == "ray-external":
+        # Starts a head-node for the cluster.
+        cluster = Cluster(
+            initialize_head=True,
+            head_node_args={
+                "num_cpus": 4,
+            },
+        )
+        yield ParallelConfig(backend="ray", address=cluster.address)
+        ray.shutdown()
+        cluster.shutdown()

--- a/tests/value/least_core/conftest.py
+++ b/tests/value/least_core/conftest.py
@@ -1,65 +1,18 @@
-from typing import Iterable, Tuple
+from typing import Tuple
 
 import numpy as np
 import pytest
 
-from pydvl.utils import Dataset, Utility
+from pydvl.utils import Utility
+from pydvl.utils.utility import MinerUtility
 from pydvl.value.results import ValuationResult, ValuationStatus
-
-
-class MinerUtility(Utility):
-    r"""
-    Consider a group of n miners, who have discovered large bars of gold.
-
-    If two miners can carry one piece of gold, then the payoff of a coalition S is:
-
-    .. math::
-
-        v(S) = \left\{\begin{matrix}
-            |S|/2 & \text{, if} & |S| \text{ is even} \\
-            (|S| - 1)/2 & \text{, if} & |S| \text{ is odd}
-        \end{matrix}\right.
-
-    If there are more than two miners and there is an even number of miners,
-    then the core consists of the single payoff where each miner gets 1/2.
-
-    If there is an odd number of miners, then the core is empty.
-
-    Taken from: https://en.wikipedia.org/wiki/Core_(game_theory)
-    """
-
-    def __init__(self, n_miners: int):
-        if n_miners <= 2:
-            raise ValueError(f"n_miners, {n_miners} should be > 2")
-        self.n_miners = n_miners
-
-        x = np.arange(n_miners)[..., np.newaxis]
-        # The y values don't matter here
-        y = np.zeros_like(x)
-
-        self.data = Dataset(x_train=x, y_train=y, x_test=x, y_test=y)
-
-    def __call__(self, indices: Iterable[int]) -> float:
-        n = len(tuple(indices))
-        if n % 2 == 0:
-            return n / 2
-        else:
-            return (n - 1) / 2
-
-    def _initialize_utility_wrapper(self):
-        pass
 
 
 @pytest.fixture()
 def miner_utility(request) -> Tuple[Utility, ValuationResult]:
     n_miners = request.param
     u = MinerUtility(n_miners=n_miners)
-    if n_miners % 2 == 0:
-        exact_values = np.array([0.5] * n_miners)
-        subsidy = 0.0
-    else:
-        exact_values = np.array([(n_miners - 1) / (2 * n_miners)] * n_miners)
-        subsidy = (n_miners - 1) / (2 * n_miners)
+    exact_values, subsidy = u.exact_least_core_values()
     result = ValuationResult(
         algorithm="exact",
         values=exact_values,

--- a/tests/value/least_core/conftest.py
+++ b/tests/value/least_core/conftest.py
@@ -4,14 +4,19 @@ import numpy as np
 import pytest
 
 from pydvl.utils import Utility
-from pydvl.utils.utility import MinerUtility
+from pydvl.utils.utility import GlovesGameUtility, MinerGameUtility
 from pydvl.value.results import ValuationResult, ValuationStatus
 
 
-@pytest.fixture()
-def miner_utility(request) -> Tuple[Utility, ValuationResult]:
-    n_miners = request.param
-    u = MinerUtility(n_miners=n_miners)
+@pytest.fixture(scope="module")
+def test_utility(request) -> Tuple[Utility, ValuationResult]:
+    name, kwargs = request.param
+    if name == "miner":
+        u = MinerGameUtility(**kwargs)
+    elif name == "gloves":
+        u = GlovesGameUtility(**kwargs)
+    else:
+        raise ValueError(f"Unknown '{name}'")
     exact_values, subsidy = u.exact_least_core_values()
     result = ValuationResult(
         algorithm="exact",

--- a/tests/value/least_core/test_montecarlo.py
+++ b/tests/value/least_core/test_montecarlo.py
@@ -9,15 +9,17 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize(
-    "miner_utility, rtol, n_iterations",
+    "test_utility, rtol, n_iterations",
     [
-        (8, 0.1, 128),
-        (15, 0.15, 6000),
+        (("miner", {"n_miners": 8}), 0.1, 128),
+        (("miner", {"n_miners": 15}), 0.15, 6000),
+        (("gloves", {"left": 4, "right": 4}), 0.1, 128),
+        (("gloves", {"left": 10, "right": 5}), 0.15, 6000),
     ],
-    indirect=["miner_utility"],
+    indirect=["test_utility"],
 )
-def test_montecarlo_least_core(miner_utility, rtol, n_iterations):
-    u, exact_values = miner_utility
+def test_montecarlo_least_core(test_utility, rtol, n_iterations):
+    u, exact_values = test_utility
 
     values = montecarlo_least_core(
         u, n_iterations=n_iterations, progress=False, n_jobs=4
@@ -26,14 +28,14 @@ def test_montecarlo_least_core(miner_utility, rtol, n_iterations):
 
 
 @pytest.mark.parametrize(
-    "miner_utility, n_iterations",
+    "test_utility, n_iterations",
     [
-        (8, 3),
+        (("miner", {"n_miners": 8}), 3),
     ],
-    indirect=["miner_utility"],
+    indirect=["test_utility"],
 )
-def test_montecarlo_least_core_failure(miner_utility, n_iterations):
-    u, exact_values = miner_utility
+def test_montecarlo_least_core_failure(test_utility, n_iterations):
+    u, exact_values = test_utility
 
     with pytest.raises(ValueError):
         montecarlo_least_core(u, n_iterations=n_iterations, progress=False, n_jobs=4)

--- a/tests/value/least_core/test_montecarlo.py
+++ b/tests/value/least_core/test_montecarlo.py
@@ -18,11 +18,21 @@ logger = logging.getLogger(__name__)
     ],
     indirect=["test_utility"],
 )
-def test_montecarlo_least_core(test_utility, rtol, n_iterations):
+@pytest.mark.parametrize(
+    "n_jobs",
+    [
+        1,
+        4,
+        pytest.param(
+            -1, marks=pytest.mark.skip("Skipping n_jobs=-1 until it is fixed")
+        ),
+    ],
+)
+def test_montecarlo_least_core(test_utility, rtol, n_iterations, n_jobs):
     u, exact_values = test_utility
 
     values = montecarlo_least_core(
-        u, n_iterations=n_iterations, progress=False, n_jobs=4
+        u, n_iterations=n_iterations, progress=False, n_jobs=n_jobs
     )
     check_values(values, exact_values, rtol=rtol, extra_values_names=["subsidy"])
 
@@ -38,4 +48,4 @@ def test_montecarlo_least_core_failure(test_utility, n_iterations):
     u, exact_values = test_utility
 
     with pytest.raises(ValueError):
-        montecarlo_least_core(u, n_iterations=n_iterations, progress=False, n_jobs=4)
+        montecarlo_least_core(u, n_iterations=n_iterations, progress=False)

--- a/tests/value/least_core/test_naive.py
+++ b/tests/value/least_core/test_naive.py
@@ -5,12 +5,21 @@ from tests.value import check_total_value, check_values
 
 
 @pytest.mark.parametrize(
-    "miner_utility",
-    [3, 4, 8, 9],
+    "test_utility",
+    [
+        ("miner", {"n_miners": 3}),
+        ("miner", {"n_miners": 4}),
+        ("miner", {"n_miners": 8}),
+        ("miner", {"n_miners": 9}),
+        ("gloves", {"left": 1, "right": 1}),
+        ("gloves", {"left": 2, "right": 1}),
+        ("gloves", {"left": 1, "right": 2}),
+        ("gloves", {"left": 3, "right": 1}),
+    ],
     indirect=True,
 )
-def test_naive_least_core(miner_utility):
-    u, exact_values = miner_utility
+def test_naive_least_core(test_utility):
+    u, exact_values = test_utility
     values = exact_least_core(u, progress=False)
     check_total_value(u, values)
     check_values(values, exact_values, extra_values_names=["subsidy"])

--- a/tests/value/shapley/test_gt.py
+++ b/tests/value/shapley/test_gt.py
@@ -8,7 +8,7 @@ from .. import check_values
 
 @pytest.mark.parametrize(
     "num_samples, fun, atol, n_iterations, kwargs",
-    [(5, group_testing_shapley, 0.05, int(1e5), {"eps": 0.05})],
+    [(5, group_testing_shapley, 0.05, int(1e5), {"eps": 0.1})],
 )
 def test_group_testing_shapley(
     num_samples, analytic_shapley, fun, atol, n_iterations, kwargs

--- a/tests/value/shapley/test_gt.py
+++ b/tests/value/shapley/test_gt.py
@@ -8,7 +8,7 @@ from .. import check_values
 
 @pytest.mark.parametrize(
     "num_samples, fun, atol, n_iterations, kwargs",
-    [(5, group_testing_shapley, 0.05, int(1e5), {"eps": 0.1})],
+    [(5, group_testing_shapley, 0.1, int(1e5), {"eps": 0.1})],
 )
 def test_group_testing_shapley(
     num_samples, analytic_shapley, fun, atol, n_iterations, kwargs

--- a/tests/value/shapley/test_montecarlo.py
+++ b/tests/value/shapley/test_montecarlo.py
@@ -248,7 +248,7 @@ def test_grouped_linear_montecarlo_shapley(
     ],
 )
 def test_random_forest(
-    boston_dataset,
+    housing_dataset,
     regressor,
     scorer: str,
     n_iterations: float,
@@ -261,7 +261,7 @@ def test_random_forest(
     pipeline and was removed."""
     rf_utility = Utility(
         regressor,
-        data=boston_dataset,
+        data=housing_dataset,
         scoring=scorer,
         enable_cache=True,
         cache_options=MemcachedConfig(

--- a/tests/value/shapley/test_montecarlo.py
+++ b/tests/value/shapley/test_montecarlo.py
@@ -33,16 +33,24 @@ log = logging.getLogger(__name__)
         (12, permutation_montecarlo_shapley, 0.1, 10, {}),
         # FIXME! it should be enough with 2**(len(data)-1) samples
         (8, combinatorial_montecarlo_shapley, 0.2, 2**10, {}),
+        (12, truncated_montecarlo_shapley, 0.1, 10, {"coordinator_update_period": 1}),
         (12, owen_sampling_shapley, 0.1, 4, {"max_q": 200, "method": "antithetic"}),
         (12, owen_sampling_shapley, 0.1, 4, {"max_q": 200, "method": "standard"}),
     ],
 )
 def test_analytic_montecarlo_shapley(
-    num_samples, analytic_shapley, fun, rtol, n_iterations, kwargs
+    num_samples, analytic_shapley, fun, rtol, n_iterations, kwargs, parallel_config
 ):
     u, exact_values = analytic_shapley
 
-    values = fun(u, n_iterations=int(n_iterations), progress=False, n_jobs=1, **kwargs)
+    values = fun(
+        u,
+        n_iterations=int(n_iterations),
+        config=parallel_config,
+        progress=False,
+        n_jobs=1,
+        **kwargs,
+    )
 
     check_values(values, exact_values, rtol=rtol)
 


### PR DESCRIPTION
### Description

This PR fixes a bug when instantiating `RayActorWrapper` on an Actor that's present on an external cluster (i.e. one that was not started with `ray.init()`.

Additionally, this modifies the `Utility` class' handling of warnings so that when using ray with small subsets
we don't end up seeing the same warning message over and over again across workers (e.g. using Naive Bayes with TMC).

### Changes

- Instantiates the worker and coordinator actors directly inside `RayActorWrapper`.
- Tests Shapley methods with different parallel backends.
- Raises an error when attempting use TMC with the sequential backend.
- Adds a warning to TMC's docstring.
- Catch all warnings in Utility when show_warnings is set to False

### Checklist

- [X] Wrote Unit tests (if necessary)
- [ ] Updated Documentation (if necessary)
- [x] Updated Changelog
- [ ] If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`
