### PR TITLE
Generalised stopping criteria, truncation policies and improved data structures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: black-jupyter
         language_version: python3
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/kynan/nbstripout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Stopping criteria for valuation algorithms. Improved `ValuationResult` and
+  `Status` classes.
+  [PR #252](https://github.com/appliedAI-Initiative/pyDVL/pull/250)
 - Operations on ValuationResults and Statuses and cleanup
   [PR #248](https://github.com/appliedAI-Initiative/pyDVL/pull/248)
 - **Bug fix and minor improvements**: Fixes bug in TMCS with remote Ray cluster,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Stopping criteria for valuation algorithms. Improved `ValuationResult` and
-  `Status` classes.
+- Generalised stopping criteria for valuation algorithms. Improved classes
+  `ValuationResult` and `Status` with more operations. Some minor issues fixed.
   [PR #252](https://github.com/appliedAI-Initiative/pyDVL/pull/250)
 - Operations on ValuationResults and Statuses and cleanup
   [PR #248](https://github.com/appliedAI-Initiative/pyDVL/pull/248)

--- a/build_scripts/update_docs.py
+++ b/build_scripts/update_docs.py
@@ -24,9 +24,6 @@ def module_template(module_qualname: str):
    :undoc-members:
    
    ----
-   
-   Module members
-   ==============
  
 .. footbibliography::
 

--- a/docs/30-data-valuation.rst
+++ b/docs/30-data-valuation.rst
@@ -217,7 +217,7 @@ v_u(x_i) = \frac{1}{n} \sum_{S \subseteq D \setminus \{x_i\}}
    values = compute_shapley_values(utility, mode="combinatorial_exact")
    df = values.to_dataframe(column='value')
 
-We convert the return value to a
+We can convert the return value to a
 `pandas DataFrame <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>`_
 and name the column with the results as `value`. Please refer to the
 documentation in :mod:`pydvl.value.shapley` and
@@ -240,11 +240,18 @@ same pattern:
    model = ...
    data = Dataset(...)
    utility = Utility(model, data)
-   values = compute_shapley_values(utility, mode="combinatorial_montecarlo")
+   values = compute_shapley_values(
+       utility, mode="combinatorial_montecarlo", done=MaxUpdates(1000)
+   )
    df = values.to_dataframe(column='cmc')
 
 The DataFrames returned by most Monte Carlo methods will contain approximate
 standard errors as an additional column, in this case named `cmc_stderr`.
+
+Note the usage of the object :class:`~pydvl.value.stopping.MaxUpdates` as the
+stop condition. This is an instance of a
+:class:`~pydvl.value.stopping.StoppingCriterion`. Other examples are
+:class:`~pydvl.value.stopping.MaxTime` and :class:`~pydvl.value.stopping.StandardError`.
 
 
 Owen sampling
@@ -281,6 +288,10 @@ sampling, and its variant *Antithetic Owen Sampling* in the documentation for th
 function doing the work behind the scenes:
 :func:`~pydvl.value.shapley.montecarlo.owen_sampling_shapley`.
 
+Note that in this case we do not pass a
+:class:`~pydvl.value.stopping.StoppingCriterion` to the function, but instead
+the number of iterations and the maximum number of samples to use in the
+integration.
 
 Permutation Shapley
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/30-data-valuation.rst
+++ b/docs/30-data-valuation.rst
@@ -174,7 +174,7 @@ definitions, but other methods are typically preferable.
    values = naive_loo(utility)
 
 The return value of all valuation functions is an object of type
-:class:`~pydvl.value.results.ValuationResult`. This can be iterated over,
+:class:`~pydvl.value.result.ValuationResult`. This can be iterated over,
 indexed with integers, slices and Iterables, as well as converted to a
 `pandas DataFrame <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>`_.
 
@@ -221,7 +221,7 @@ We convert the return value to a
 `pandas DataFrame <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>`_
 and name the column with the results as `value`. Please refer to the
 documentation in :mod:`pydvl.value.shapley` and
-:class:`~pydvl.value.results.ValuationResult` for more information.
+:class:`~pydvl.value.result.ValuationResult` for more information.
 
 Monte Carlo Combinatorial Shapley
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/30-data-valuation.rst
+++ b/docs/30-data-valuation.rst
@@ -320,7 +320,7 @@ efficient enough to be useful in some applications.
    data = Dataset(...)
    utility = Utility(model, data)
    values = compute_shapley_values(
-       u=utility, mode="truncated_montecarlo", n_iterations=100
+       u=utility, mode="truncated_montecarlo", done=MaxUpdates(1000)
    )
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 black[jupyter] == 22.10.0
-isort == 5.10.1
+isort == 5.12.0
 jupyter
 mypy == 0.982
 nbconvert

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,13 +2,13 @@ black[jupyter] == 22.10.0
 isort == 5.12.0
 jupyter
 mypy == 0.982
-nbconvert
+nbconvert>=7.2.9
 nbstripout == 0.6.1
 bump2version
-pre-commit == 2.20.0
-pytest
+pre-commit==3.0.4
+pytest==7.2.1
 pytest-cov
-pytest-docker
+pytest-docker==0.12.0
 pytest-mock
 pytest-timeout
 ray[default] >= 0.8

--- a/src/pydvl/reporting/scores.py
+++ b/src/pydvl/reporting/scores.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from pydvl.utils import Utility, maybe_progress
-from pydvl.value.results import ValuationResult
+from pydvl.value.result import ValuationResult
 
 __all__ = [
     "sort_values",
@@ -66,11 +66,7 @@ def compute_removal_score(
     # We sort in descending order if we want to remove the best values
     values.sort(reverse=remove_best)
 
-    for pct in maybe_progress(
-        percentages,
-        display=progress,
-        desc="Removal Scores",
-    ):
+    for pct in maybe_progress(percentages, display=progress, desc="Removal Scores"):
         n_removal = int(pct * len(u.data))
         indices = values.indices[n_removal:]
         score = u(indices)

--- a/src/pydvl/reporting/scores.py
+++ b/src/pydvl/reporting/scores.py
@@ -1,6 +1,4 @@
-from collections import OrderedDict
-from operator import itemgetter
-from typing import Dict, Iterable, Mapping, Sequence, TypeVar, Union
+from typing import Dict, Iterable, Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -8,36 +6,13 @@ from numpy.typing import NDArray
 from pydvl.utils import Utility, maybe_progress
 from pydvl.value.result import ValuationResult
 
-__all__ = [
-    "sort_values",
-    "sort_values_array",
-    "sort_values_history",
-    "compute_removal_score",
-]
-
-KT = TypeVar("KT")
-VT = TypeVar("VT")
-
-
-def sort_values_array(values: np.ndarray) -> Dict[int, "NDArray"]:
-    vals = np.mean(values, axis=1)
-    return OrderedDict(sorted(enumerate(vals), key=itemgetter(1)))
-
-
-def sort_values_history(values: Mapping[KT, Sequence[VT]]) -> Dict[KT, Sequence[VT]]:
-    """Sorts a dict of sample_id: [values] by the last item in each list."""
-    return OrderedDict(sorted(values.items(), key=itemgetter(1, -1)))
-
-
-def sort_values(values: Mapping[KT, VT]) -> Dict[KT, VT]:
-    """Sorts a dict of sample_id: value_float by value."""
-    return OrderedDict(sorted(values.items(), key=itemgetter(1)))
+__all__ = ["compute_removal_score"]
 
 
 def compute_removal_score(
     u: Utility,
     values: ValuationResult,
-    percentages: Union["NDArray", Iterable[float]],
+    percentages: Union[NDArray[np.float_], Iterable[float]],
     *,
     remove_best: bool = False,
     progress: bool = False,

--- a/src/pydvl/utils/caching.py
+++ b/src/pydvl/utils/caching.py
@@ -271,7 +271,7 @@ def memcached(
                     ):
                         new_value = fun(*args, **kwargs)
                         new_avg, new_var = running_moments(
-                            value, variance, cast(float, new_value), int(count)
+                            value, variance, int(count), cast(float, new_value)
                         )
                         result_dict["value"] = new_avg
                         result_dict["count"] = count + 1

--- a/src/pydvl/utils/dataset.py
+++ b/src/pydvl/utils/dataset.py
@@ -408,7 +408,7 @@ class GroupedDataset(Dataset):
         train_size: float = 0.8,
         random_state: Optional[int] = None,
         stratify_by_target: bool = False,
-        data_groups: Optional[List] = None,
+        data_groups: Optional[Sequence] = None,
     ) -> "GroupedDataset":
         """Constructs a :class:`GroupedDataset` object from an sklearn bunch as returned by the
         `load_*` functions in `sklearn toy datasets
@@ -444,7 +444,7 @@ class GroupedDataset(Dataset):
         train_size: float = 0.8,
         random_state: Optional[int] = None,
         stratify_by_target: bool = False,
-        data_groups: Optional[List] = None,
+        data_groups: Optional[Sequence] = None,
     ) -> "Dataset":
         """.. versionadded:: 0.4.0
 

--- a/src/pydvl/utils/numeric.py
+++ b/src/pydvl/utils/numeric.py
@@ -69,20 +69,22 @@ def num_samples_permutation_hoeffding(eps: float, delta: float, u_range: float) 
 
 
 def random_powerset(
-    s: NDArray[T], max_subsets: Optional[int] = None, q: float = 0.5
+    s: NDArray[T], n_samples: Optional[int] = None, q: float = 0.5
 ) -> Generator[NDArray[T], None, None]:
     """Samples subsets from the power set of the argument, without
     pre-generating all subsets and in no order.
 
     See `powerset()` if you wish to deterministically generate all subsets.
 
-    To generate subsets, `len(s)` Bernoulli draws with probability `q` are drawn.
+    To generate subsets, `len(s)` Bernoulli draws with probability `q` are
+    drawn.
     The default value of `q = 0.5` provides a uniform distribution over the
     power set of `s`. Other choices can be used e.g. to implement
-    :func:`Owen sampling <pydvl.value.shapley.montecarlo.owen_sampling_shapley>`.
+    :func:`Owen sampling
+    <pydvl.value.shapley.montecarlo.owen_sampling_shapley>`.
 
     :param s: set to sample from
-    :param max_subsets: if set, stop the generator after this many steps.
+    :param n_samples: if set, stop the generator after this many steps.
         Defaults to `np.iinfo(np.int32).max`
     :param q: Sampling probability for elements. The default 0.5 yields a
         uniform distribution over the power set of s.
@@ -99,9 +101,9 @@ def random_powerset(
 
     rng = np.random.default_rng()
     total = 1
-    if max_subsets is None:
-        max_subsets = np.iinfo(np.int32).max
-    while total <= max_subsets:
+    if n_samples is None:
+        n_samples = np.iinfo(np.int32).max
+    while total <= n_samples:
         selection = rng.uniform(size=len(s)) > q
         subset = s[selection]
         yield subset

--- a/src/pydvl/utils/numeric.py
+++ b/src/pydvl/utils/numeric.py
@@ -230,8 +230,8 @@ def linear_regression_analytical_derivative_d_x_d_theta(
 def running_moments(
     previous_avg: FloatOrArray,
     previous_variance: FloatOrArray,
-    new_value: FloatOrArray,
     count: IntOrArray,
+    new_value: FloatOrArray,
 ) -> Tuple:  # [FloatOrArray, FloatOrArray]:
     """Uses Welford's algorithm to calculate the running average and variance of
      a set of numbers.
@@ -250,8 +250,8 @@ def running_moments(
 
     :param previous_avg: average value at previous step
     :param previous_variance: variance at previous step
-    :param new_value: new value in the series of numbers
     :param count: number of points seen so far
+    :param new_value: new value in the series of numbers
     :return: new_average, new_variance, calculated with the new count
     """
     # broadcasted operations seem not to be supported by mypy, so we ignore the type

--- a/src/pydvl/utils/parallel/actor.py
+++ b/src/pydvl/utils/parallel/actor.py
@@ -1,7 +1,7 @@
 import abc
 import inspect
 import logging
-from typing import Generic, List, TypeVar, Optional, Type, cast
+from typing import Generic, List, Optional, Type, TypeVar, cast
 
 from ..config import ParallelConfig
 from ..status import Status

--- a/src/pydvl/utils/parallel/actor.py
+++ b/src/pydvl/utils/parallel/actor.py
@@ -1,6 +1,7 @@
 import abc
 import inspect
 import logging
+from time import sleep
 from typing import Generic, List, Optional, Type, TypeVar, cast
 
 from ..config import ParallelConfig
@@ -66,7 +67,7 @@ class RayActorWrapper:
                 setattr(self, name, remote_caller(name))
 
 
-Result = TypeVar("Result")
+Result = TypeVar("Result")  # Avoids circular import with ValuationResult
 
 
 class Coordinator(Generic[Result], abc.ABC):
@@ -103,10 +104,8 @@ class Coordinator(Generic[Result], abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def check_done(self) -> bool:
-        """Checks whether the accuracy of the calculation or the total number
-        of iterations have crossed the set thresholds.
-        """
+    def check_convergence(self) -> bool:
+        """Evaluates the convergence criteria on the aggregated results."""
         raise NotImplementedError()
 
 

--- a/src/pydvl/utils/parallel/map_reduce.py
+++ b/src/pydvl/utils/parallel/map_reduce.py
@@ -70,6 +70,13 @@ def _(v: np.ndarray, *, timeout: Optional[float] = None) -> NDArray:
     return v
 
 
+# FIXME: This is very strange. Not adding a special case for strings results
+#  in infinite recursion.
+@_get_value.register
+def _(v: str, *, timeout: Optional[float] = None) -> str:
+    return v
+
+
 @_get_value.register
 def _(v: Iterable, *, timeout: Optional[float] = None) -> List[Any]:
     return [_get_value(x, timeout=timeout) for x in v]

--- a/src/pydvl/utils/parallel/map_reduce.py
+++ b/src/pydvl/utils/parallel/map_reduce.py
@@ -1,5 +1,4 @@
 import inspect
-from collections.abc import Iterable
 from functools import singledispatch, update_wrapper
 from itertools import accumulate, repeat
 from typing import (
@@ -70,15 +69,9 @@ def _(v: np.ndarray, *, timeout: Optional[float] = None) -> NDArray:
     return v
 
 
-# FIXME: This is very strange. Not adding a special case for strings results
-#  in infinite recursion.
+# Careful to use list as hint. The dispatch does not work with typing generics
 @_get_value.register
-def _(v: str, *, timeout: Optional[float] = None) -> str:
-    return v
-
-
-@_get_value.register
-def _(v: Iterable, *, timeout: Optional[float] = None) -> List[Any]:
+def _(v: list, *, timeout: Optional[float] = None) -> List[Any]:
     return [_get_value(x, timeout=timeout) for x in v]
 
 

--- a/src/pydvl/utils/status.py
+++ b/src/pydvl/utils/status.py
@@ -68,7 +68,6 @@ class Status(Enum):
     Failed = "failed"
 
     def __or__(self, other: "Status") -> "Status":
-        """ """
         if self == Status.Converged or other == Status.Converged:
             return Status.Converged
         if self == Status.Pending or other == Status.Pending:
@@ -79,6 +78,7 @@ class Status(Enum):
         raise RuntimeError(f"Unexpected statuses: {self} and {other}")
 
     def __and__(self, other: "Status") -> "Status":
+        # Careful, the order of tests matters here!
         if self == Status.Failed or other == Status.Failed:
             return Status.Failed
         if self == Status.Pending or other == Status.Pending:

--- a/src/pydvl/utils/status.py
+++ b/src/pydvl/utils/status.py
@@ -60,6 +60,11 @@ class Status(Enum):
         bool(Status.Converged) == True
         bool(Status.Failed) == False
 
+    :warning:
+        These truth values are **inconsistent** with the usual boolean operations.
+        In particular the XOR of two ``Status``es is not the same as the XOR of
+        their boolean values.
+
     """
 
     Pending = "pending"

--- a/src/pydvl/utils/status.py
+++ b/src/pydvl/utils/status.py
@@ -92,10 +92,10 @@ class Status(Enum):
         # Should be unreachable
         raise RuntimeError(f"Unexpected statuses: {self} and {other}")
 
-    def __invert__(self):
+    def __invert__(self) -> "Status":
         if self == Status.Converged:
             return Status.Failed
         return Status.Converged
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return self != Status.Pending

--- a/src/pydvl/utils/status.py
+++ b/src/pydvl/utils/status.py
@@ -60,10 +60,10 @@ class Status(Enum):
         bool(Status.Converged) == True
         bool(Status.Failed) == False
 
-    :warning:
-        These truth values are **inconsistent** with the usual boolean operations.
-        In particular the XOR of two ``Status``es is not the same as the XOR of
-        their boolean values.
+    .. warning::
+       These truth values are **inconsistent** with the usual boolean operations.
+       In particular the XOR of two instances of ``Status`` is not the same as
+       the XOR of their boolean values.
 
     """
 

--- a/src/pydvl/utils/status.py
+++ b/src/pydvl/utils/status.py
@@ -54,11 +54,11 @@ class Status(Enum):
 
     :Boolean casting:
 
-    A Status evaluates to ``True`` iff it's ``Converged`` or ``MaxIterations``
+    A Status evaluates to ``True`` iff it's ``Converged`` or ``Failed``:
 
         bool(Status.Pending) == False
         bool(Status.Converged) == True
-        bool(Status.Failed) == False
+        bool(Status.Failed) == True
 
     .. warning::
        These truth values are **inconsistent** with the usual boolean operations.
@@ -69,7 +69,6 @@ class Status(Enum):
 
     Pending = "pending"
     Converged = "converged"
-    MaxIterations = "maximum number of iterations reached"
     Failed = "failed"
 
     def __or__(self, other: "Status") -> "Status":
@@ -79,7 +78,7 @@ class Status(Enum):
             return Status.Pending
         if self == Status.Failed and other == Status.Failed:
             return Status.Failed
-        # TODO: Should be unreachable after deleting MaxIterations:
+        # Should be unreachable
         raise RuntimeError(f"Unexpected statuses: {self} and {other}")
 
     def __and__(self, other: "Status") -> "Status":
@@ -90,7 +89,7 @@ class Status(Enum):
             return Status.Pending
         if self == Status.Converged and other == Status.Converged:
             return Status.Converged
-        # TODO: Should be unreachable after deleting MaxIterations:
+        # Should be unreachable
         raise RuntimeError(f"Unexpected statuses: {self} and {other}")
 
     def __invert__(self):
@@ -99,4 +98,4 @@ class Status(Enum):
         return Status.Converged
 
     def __bool__(self):
-        return self == Status.Converged or self == Status.MaxIterations
+        return self != Status.Pending

--- a/src/pydvl/utils/utility.py
+++ b/src/pydvl/utils/utility.py
@@ -62,7 +62,8 @@ class Utility:
     :param scoring: Same as in sklearn's ``cross_validate()``: a string,
         a scorer callable or None for the default ``model.score()``. Greater
         values must be better. If they are not, a negated version can be
-        used (see `make_scorer`)
+        used (see scikit-learn's `make_scorer()
+        <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.make_scorer.html>_`)
     :param default_score: score in the case of models that have not been fit,
         e.g. when too little data is passed, or errors arise.
     :param score_range: numerical range of the score function. Some Monte Carlo

--- a/src/pydvl/utils/utility.py
+++ b/src/pydvl/utils/utility.py
@@ -42,8 +42,8 @@ class Utility:
     :ref:`Least Core values<Least Core>`.
 
     The Utility expect the model to fulfill
-    the :class:`pydvl.utils.types.SupervisedModel` interface
-    i.e. to have a `fit()`, `predict()`, and `score()` methods.
+    the :class:`pydvl.utils.types.SupervisedModel` interface i.e. to have
+    ``fit()``, ``predict()``, and ``score()`` methods.
 
     When calling the utility, the model will be
     `cloned <https://scikit-learn.org/stable/modules/generated/sklearn.base.clone.html>`_
@@ -51,7 +51,7 @@ class Utility:
     from the builtin `copy <https://docs.python.org/3/library/copy.html>`_ module.
 
     Since evaluating the scoring function requires retraining the model
-    and that can be time consuming, this class wraps it and caches
+    and that can be time-consuming, this class wraps it and caches
     the results of each execution. Caching is available both locally
     and across nodes, but must always be enabled for your
     project first, see :ref:`how to set up the cache<caching setup>`.
@@ -68,11 +68,11 @@ class Utility:
     :param score_range: numerical range of the score function. Some Monte Carlo
         methods can use this to estimate the number of samples required for a
         certain quality of approximation.
-    :param catch_errors: set to True to catch the errors when fit() fails. This
-        could happen in several steps of the pipeline, e.g. when too little
-        training data is passed, which happens often during the Shapley value calculations.
-        When this happens, the default_score is returned as a score and value
-        calculation continues.
+    :param catch_errors: set to ``True`` to catch the errors when `fit()` fails.
+        This can happen in several steps of the pipeline, e.g. when too little
+        training data is used, something that happens often during Shapley value
+        calculations. In this case, the :attr:`default_score` is returned by
+        the utility.
     :param show_warnings: True for printing warnings fit fails.
     :param enable_cache: If True, use memcached for memoization.
     :param cache_options: Optional configuration object for memcached.
@@ -141,19 +141,20 @@ class Utility:
     def _utility(self, indices: FrozenSet) -> float:
         """Clones the model, fits it on a subset of the training data
         and scores it on the test data.
-        If the object is constructed with `enable_cache = True`,
-        results are memoized to avoid duplicate computation. This is useful in
-        particular when computing utilities of permutations of indices or when
-        randomly sampling from the powerset of indices.
+
+        If the object is constructed with ``enable_cache = True``, results are
+        memoized to avoid duplicate computation. This is useful in particular
+        when computing utilities of permutations of indices or when randomly
+        sampling from the powerset of indices.
 
         :param indices: a subset of valid indices for
             :attr:`~pydvl.utils.dataset.Dataset.x_train`. The type must be
             hashable for the caching to work, e.g. wrap the argument with
             `frozenset <https://docs.python.org/3/library/stdtypes.html#frozenset>`_
             (rather than `tuple` since order should not matter)
-        :return: 0 if no indices are passed, `default_score` if we fail to fit
-            the model or the scorer returns NaN, otherwise the score on the test
-            data.
+        :return: 0 if no indices are passed, :attr:`default_score`` if we fail
+            to fit the model or the scorer returns `NaN`. Otherwise, the score
+            of the model on the test data.
         """
         if not indices:
             return 0.0

--- a/src/pydvl/value/__init__.py
+++ b/src/pydvl/value/__init__.py
@@ -5,7 +5,7 @@ See :ref:`data valuation` for an introduction to the concepts and methods
 implemented here.
 """
 
-from .results import *  # isort: skip
+from .result import *  # isort: skip
 from .least_core import *
 from .loo import *
 from .shapley import *

--- a/src/pydvl/value/least_core/montecarlo.py
+++ b/src/pydvl/value/least_core/montecarlo.py
@@ -15,7 +15,7 @@ from pydvl.value.least_core._common import (
     _solve_egalitarian_least_core_quadratic_program,
     _solve_least_core_linear_program,
 )
-from pydvl.value.results import ValuationResult
+from pydvl.value.result import ValuationResult
 
 logger = logging.getLogger(__name__)
 
@@ -24,12 +24,7 @@ __all__ = ["montecarlo_least_core"]
 
 
 def _montecarlo_least_core(
-    u: Utility,
-    n_iterations: int,
-    *,
-    progress: bool = False,
-    job_id: int = 1,
-    **kwargs,
+    u: Utility, n_iterations: int, *, progress: bool = False, job_id: int = 1, **kwargs
 ) -> Tuple[NDArray[np.float_], NDArray[np.float_]]:
     """Computes utility values and the Least Core upper bound matrix for a given number of iterations.
 
@@ -44,20 +39,12 @@ def _montecarlo_least_core(
     utility_values = np.zeros(n_iterations)
 
     # Randomly sample subsets of full dataset
-    power_set = random_powerset(
-        u.data.indices,
-        max_subsets=n_iterations,
-    )
+    power_set = random_powerset(u.data.indices, n_samples=n_iterations)
 
     A_lb = np.zeros((n_iterations, n))
 
     for i, subset in enumerate(
-        maybe_progress(
-            power_set,
-            progress,
-            total=n_iterations,
-            position=job_id,
-        )
+        maybe_progress(power_set, progress, total=n_iterations, position=job_id)
     ):
         indices = np.zeros(n, dtype=bool)
         indices[list(subset)] = True
@@ -141,10 +128,7 @@ def montecarlo_least_core(
         inputs=u,
         map_func=_montecarlo_least_core,
         reduce_func=_reduce_func,
-        map_kwargs=dict(
-            n_iterations=iterations_per_job,
-            progress=progress,
-        ),
+        map_kwargs=dict(n_iterations=iterations_per_job, progress=progress),
         n_jobs=n_jobs,
         config=config,
     )
@@ -190,12 +174,7 @@ def montecarlo_least_core(
         )
 
     values = _solve_egalitarian_least_core_quadratic_program(
-        subsidy,
-        A_eq=A_eq,
-        b_eq=b_eq,
-        A_lb=A_lb,
-        b_lb=b_lb,
-        **options,
+        subsidy, A_eq=A_eq, b_eq=b_eq, A_lb=A_lb, b_lb=b_lb, **options
     )
 
     if values is None:

--- a/src/pydvl/value/least_core/montecarlo.py
+++ b/src/pydvl/value/least_core/montecarlo.py
@@ -169,7 +169,6 @@ def montecarlo_least_core(
             status=status,
             values=values,
             subsidy=subsidy,
-            stderr=None,
             data_names=u.data.data_names,
         )
 
@@ -191,6 +190,5 @@ def montecarlo_least_core(
         status=status,
         values=values,
         subsidy=subsidy,
-        stderr=None,
         data_names=u.data.data_names,
     )

--- a/src/pydvl/value/least_core/naive.py
+++ b/src/pydvl/value/least_core/naive.py
@@ -98,7 +98,6 @@ def exact_least_core(
             status=status,
             values=values,
             subsidy=subsidy,
-            stderr=None,
             data_names=u.data.data_names,
         )
 
@@ -120,6 +119,5 @@ def exact_least_core(
         status=status,
         values=values,
         subsidy=subsidy,
-        stderr=None,
         data_names=u.data.data_names,
     )

--- a/src/pydvl/value/least_core/naive.py
+++ b/src/pydvl/value/least_core/naive.py
@@ -89,8 +89,7 @@ def exact_least_core(
     if subsidy is None:
         logger.debug("No values were found")
         status = Status.Failed
-        values = np.empty(n)
-        values[:] = np.nan
+        values = np.full(n, np.nan)
         subsidy = np.nan
 
         return ValuationResult(
@@ -108,8 +107,7 @@ def exact_least_core(
     if values is None:
         logger.debug("No values were found")
         status = Status.Failed
-        values = np.empty(n)
-        values[:] = np.nan
+        values = np.full(n, np.nan)
         subsidy = np.nan
     else:
         status = Status.Converged

--- a/src/pydvl/value/least_core/naive.py
+++ b/src/pydvl/value/least_core/naive.py
@@ -11,7 +11,7 @@ from pydvl.value.least_core._common import (
     _solve_egalitarian_least_core_quadratic_program,
     _solve_least_core_linear_program,
 )
-from pydvl.value.results import ValuationResult
+from pydvl.value.result import ValuationResult
 
 __all__ = ["exact_least_core"]
 
@@ -69,10 +69,7 @@ def exact_least_core(
     utility_values = np.zeros(powerset_size)
     for i, subset in enumerate(
         maybe_progress(
-            powerset(u.data.indices),
-            progress,
-            total=powerset_size - 1,
-            position=0,
+            powerset(u.data.indices), progress, total=powerset_size - 1, position=0
         )
     ):
         indices = np.zeros(n, dtype=bool)
@@ -106,12 +103,7 @@ def exact_least_core(
         )
 
     values = _solve_egalitarian_least_core_quadratic_program(
-        subsidy,
-        A_eq=A_eq,
-        b_eq=b_eq,
-        A_lb=A_lb,
-        b_lb=b_lb,
-        **options,
+        subsidy, A_eq=A_eq, b_eq=b_eq, A_lb=A_lb, b_lb=b_lb, **options
     )
 
     if values is None:

--- a/src/pydvl/value/loo/naive.py
+++ b/src/pydvl/value/loo/naive.py
@@ -31,6 +31,5 @@ def naive_loo(u: Utility, *, progress: bool = True) -> ValuationResult:
         algorithm="naive_loo",
         status=Status.Converged,
         values=values,
-        stderr=None,
         data_names=u.data.data_names,
     )

--- a/src/pydvl/value/loo/naive.py
+++ b/src/pydvl/value/loo/naive.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from pydvl.utils import Utility, maybe_progress
 from pydvl.utils.status import Status
-from pydvl.value.results import ValuationResult
+from pydvl.value.result import ValuationResult
 
 __all__ = ["naive_loo"]
 

--- a/src/pydvl/value/result.py
+++ b/src/pydvl/value/result.py
@@ -278,7 +278,7 @@ class ValuationResult(collections.abc.Sequence):
             ) from e
 
     @overload
-    def __getitem__(self, key: Integral) -> ValueItem:
+    def __getitem__(self, key: int) -> ValueItem:
         ...
 
     @overload
@@ -286,11 +286,11 @@ class ValuationResult(collections.abc.Sequence):
         ...
 
     @overload
-    def __getitem__(self, key: Iterable[Integral]) -> List[ValueItem]:
+    def __getitem__(self, key: Iterable[int]) -> List[ValueItem]:
         ...
 
     def __getitem__(
-        self, key: Union[slice, Iterable[Integral], Integral]
+        self, key: Union[slice, Iterable[int], int]
     ) -> Union[ValueItem, List[ValueItem]]:
         if isinstance(key, slice):
             return [cast(ValueItem, self[i]) for i in range(*key.indices(len(self)))]
@@ -299,7 +299,7 @@ class ValuationResult(collections.abc.Sequence):
         elif isinstance(key, Integral):
             if key < 0:
                 key += len(self)
-            if key < 0 or key >= len(self):
+            if key < 0 or int(key) >= len(self):
                 raise IndexError(f"Index {key} out of range (0, {len(self)}).")
             idx = self._sort_indices[key]
             return ValueItem(
@@ -313,7 +313,7 @@ class ValuationResult(collections.abc.Sequence):
             raise TypeError("Indices must be integers, iterable or slices")
 
     @overload
-    def __setitem__(self, key: Integral, value: ValueItem) -> None:
+    def __setitem__(self, key: int, value: ValueItem) -> None:
         ...
 
     @overload
@@ -321,11 +321,11 @@ class ValuationResult(collections.abc.Sequence):
         ...
 
     @overload
-    def __setitem__(self, key: Iterable[Integral], value: ValueItem) -> None:
+    def __setitem__(self, key: Iterable[int], value: ValueItem) -> None:
         ...
 
     def __setitem__(
-        self, key: Union[slice, Iterable[Integral], Integral], value: ValueItem
+        self, key: Union[slice, Iterable[int], int], value: ValueItem
     ) -> None:
         if isinstance(key, slice):
             for i in range(*key.indices(len(self))):
@@ -336,7 +336,7 @@ class ValuationResult(collections.abc.Sequence):
         elif isinstance(key, Integral):
             if key < 0:
                 key += len(self)
-            if key < 0 or key >= len(self):
+            if key < 0 or int(key) >= len(self):
                 raise IndexError(f"Index {key} out of range (0, {len(self)}).")
             idx = self._sort_indices[key]
             self._indices[idx] = value.index
@@ -485,7 +485,7 @@ class ValuationResult(collections.abc.Sequence):
             # extra_values=self._extra_values.update(other._extra_values),
         )
 
-    def update(self, idx: Integral, new_value: float) -> "ValuationResult":
+    def update(self, idx: int, new_value: float) -> "ValuationResult":
         """Updates the result in place with a new value, using running mean
         and variance.
 
@@ -551,7 +551,7 @@ class ValuationResult(collections.abc.Sequence):
     def empty(
         cls,
         algorithm: str = "",
-        indices: Optional[Sequence[Integral]] = None,
+        indices: Optional[Union[Sequence[int], NDArray[np.int_]]] = None,
         n_samples: int = 0,
     ) -> "ValuationResult":
         """Creates an empty :class:`ValuationResult` object.

--- a/src/pydvl/value/result.py
+++ b/src/pydvl/value/result.py
@@ -301,7 +301,7 @@ class ValuationResult(collections.abc.Sequence):
            and standard errors are "unwrapped" and recomputed again.
 
         Means and standard errors are correctly handled. Statuses are added with
-        bit-wise ``&``, see :class:`~pydvl.value.results.Status`.
+        bit-wise ``&``, see :class:`~pydvl.value.result.Status`.
         ``data_names`` are taken from the left summand, or if unavailable from
         the right one. The ``algorithm`` string is carried over if both terms
         have the same one or concatenated.
@@ -400,11 +400,7 @@ class ValuationResult(collections.abc.Sequence):
         :return: An instance of :class:`ValuationResult`
         """
         values = np.random.uniform(low=-1.0, high=1.0, size=size)
-        return cls(
-            algorithm="random",
-            status=Status.Converged,
-            values=values,
-        )
+        return cls(algorithm="random", status=Status.Converged, values=values)
 
     @classmethod
     def empty(cls, algorithm: str = "", n_samples: int = 0) -> "ValuationResult":

--- a/src/pydvl/value/result.py
+++ b/src/pydvl/value/result.py
@@ -327,6 +327,8 @@ class ValuationResult(collections.abc.Sequence):
             self._values[idx] = value.value
             self._variances[idx] = value.variance
             self._counts[idx] = value.count
+        else:
+            raise TypeError("Indices must be integers, iterable or slices")
 
     def __iter__(self) -> Generator[ValueItem, Any, None]:
         """Iterate over the results returning :class:`ValueItem` objects.

--- a/src/pydvl/value/result.py
+++ b/src/pydvl/value/result.py
@@ -11,6 +11,7 @@ import collections.abc
 import logging
 from dataclasses import dataclass
 from functools import total_ordering
+from numbers import Integral
 from typing import (
     Any,
     Generator,
@@ -261,7 +262,7 @@ class ValuationResult(collections.abc.Sequence):
             ) from e
 
     @overload
-    def __getitem__(self, key: int) -> ValueItem:
+    def __getitem__(self, key: Integral) -> ValueItem:
         ...
 
     @overload
@@ -269,17 +270,17 @@ class ValuationResult(collections.abc.Sequence):
         ...
 
     @overload
-    def __getitem__(self, key: Iterable[int]) -> List[ValueItem]:
+    def __getitem__(self, key: Iterable[Integral]) -> List[ValueItem]:
         ...
 
     def __getitem__(
-        self, key: Union[slice, Iterable[int], int]
+        self, key: Union[slice, Iterable[Integral], Integral]
     ) -> Union[ValueItem, List[ValueItem]]:
         if isinstance(key, slice):
             return [cast(ValueItem, self[i]) for i in range(*key.indices(len(self)))]
         elif isinstance(key, collections.abc.Iterable):
             return [cast(ValueItem, self[i]) for i in key]
-        elif isinstance(key, int):
+        elif isinstance(key, Integral):
             if key < 0:
                 key += len(self)
             if key < 0 or key >= len(self):
@@ -296,7 +297,7 @@ class ValuationResult(collections.abc.Sequence):
             raise TypeError("Indices must be integers, iterable or slices")
 
     @overload
-    def __setitem__(self, key: int, value: ValueItem) -> None:
+    def __setitem__(self, key: Integral, value: ValueItem) -> None:
         ...
 
     @overload
@@ -304,11 +305,11 @@ class ValuationResult(collections.abc.Sequence):
         ...
 
     @overload
-    def __setitem__(self, key: Iterable[int], value: ValueItem) -> None:
+    def __setitem__(self, key: Iterable[Integral], value: ValueItem) -> None:
         ...
 
     def __setitem__(
-        self, key: Union[slice, Iterable[int], int], value: ValueItem
+        self, key: Union[slice, Iterable[Integral], Integral], value: ValueItem
     ) -> None:
         if isinstance(key, slice):
             for i in range(*key.indices(len(self))):
@@ -466,7 +467,7 @@ class ValuationResult(collections.abc.Sequence):
             # FIXME: what about extra args?
         )
 
-    def update(self, idx: int, new_value: float) -> "ValuationResult":
+    def update(self, idx: Integral, new_value: float) -> "ValuationResult":
         """Updates the result in place with a new value, using running mean
         and variance.
 
@@ -483,7 +484,7 @@ class ValuationResult(collections.abc.Sequence):
         self[idx] = ValueItem(idx, self._names[idx], val, var, self._counts[idx] + 1)
         return self
 
-    def get(self, idx: int) -> ValueItem:
+    def get(self, idx: Integral) -> ValueItem:
         """Retrieves a ValueItem by data index, as opposed to sort index, like
         the indexing operator.
         """

--- a/src/pydvl/value/result.py
+++ b/src/pydvl/value/result.py
@@ -496,8 +496,8 @@ class ValuationResult(collections.abc.Sequence):
         val, var = running_moments(
             self._values[idx],
             self._variances[idx],
-            new_value,
             self._counts[idx],
+            new_value,
         )
         self[idx] = ValueItem(idx, self._names[idx], val, var, self._counts[idx] + 1)
         return self

--- a/src/pydvl/value/result.py
+++ b/src/pydvl/value/result.py
@@ -109,8 +109,27 @@ class ValuationResult(collections.abc.Sequence):
     In order to access :class:`ValueItem` objects by their data index, use
     :meth:`get`.
 
-    :param values: An array of values, data indices correspond to positions in
-        the array.
+    .. rubric:: Operating on results
+
+    Results can be added to each other with the ``+`` operator. Means and
+    variances are correctly updated, using the ``counts`` attribute.
+
+    Results can also be updated with new values using :meth:`update`. Means and
+    variances are updated accordingly using the Welford algorithm.
+
+    Empty objects behave in a special way:
+
+    .. rubric:: Empty results
+
+    Empty results are characterised by having an empty array of values and
+    an empty algorithm name. When another result is added to an empty one,
+    the empty one is ignored. Alternatively, one can set the algorithm name
+    and length of the array of values in this function. This makes creating
+    subsequent ValuationResults to add to it a bit less verbose (since the
+    algorithm name does not have to be repeated).
+
+    :param values: An array of values. If omitted, defaults to an empty array
+        or to an array of zeros if ``indices`` are given.
     :param indices: An optional array of indices in the original dataset. If
         omitted, defaults to ``np.arange(len(values))``.
     :param variance: An optional array of variances in the computation of each

--- a/src/pydvl/value/shapley/__init__.py
+++ b/src/pydvl/value/shapley/__init__.py
@@ -29,7 +29,7 @@ __all__ = ["compute_shapley_values"]
 def compute_shapley_values(
     u: Utility,
     *,
-    stop: StoppingCriterion = MaxUpdates(100),
+    done: StoppingCriterion = MaxUpdates(100),
     mode: ShapleyMode = ShapleyMode.TruncatedMontecarlo,
     n_jobs: int = 1,
     **kwargs,
@@ -84,7 +84,7 @@ def compute_shapley_values(
 
     :param u: :class:`~pydvl.utils.utility.Utility` object with model, data, and
         scoring function.
-    :param stop: :class:`~pydvl.value.stopping.StoppingCriterion` object, used
+    :param done: :class:`~pydvl.value.stopping.StoppingCriterion` object, used
         to determine when to stop the computation for Monte Carlo methods. The
         default is to stop after 100 iterations. See the available criteria in
         :mod:`~pydvl.value.stopping`. It is possible to combine several criteria
@@ -104,14 +104,14 @@ def compute_shapley_values(
         raise ValueError(f"Invalid value encountered in {mode=}")
 
     if mode == ShapleyMode.TruncatedMontecarlo:
-        return truncated_montecarlo_shapley(u=u, stop=stop, n_jobs=n_jobs, **kwargs)
+        return truncated_montecarlo_shapley(u=u, done=done, n_jobs=n_jobs, **kwargs)
     elif mode == ShapleyMode.CombinatorialMontecarlo:
         return combinatorial_montecarlo_shapley(
-            u, stop=stop, n_jobs=n_jobs, progress=progress
+            u, done=done, n_jobs=n_jobs, progress=progress
         )
     elif mode == ShapleyMode.PermutationMontecarlo:
         return permutation_montecarlo_shapley(
-            u, stop=stop, n_jobs=n_jobs, progress=progress
+            u, done=done, n_jobs=n_jobs, progress=progress
         )
     elif mode == ShapleyMode.CombinatorialExact:
         return combinatorial_exact_shapley(u, n_jobs=n_jobs, progress=progress)
@@ -130,7 +130,7 @@ def compute_shapley_values(
         )
         return owen_sampling_shapley(
             u,
-            n_iterations=int(kwargs.get("n_samples", -1)),
+            n_iterations=int(kwargs.get("n_iterations", -1)),
             max_q=int(kwargs.get("max_q", -1)),
             method=method,
             n_jobs=n_jobs,

--- a/src/pydvl/value/shapley/__init__.py
+++ b/src/pydvl/value/shapley/__init__.py
@@ -125,10 +125,6 @@ def compute_shapley_values(
             u, n_iterations=n_iterations, n_jobs=n_jobs, progress=progress
         )
     elif mode == ShapleyMode.PermutationMontecarlo:
-        if n_iterations is None:
-            raise ValueError(
-                "n_iterations cannot be None for Permutation Montecarlo Shapley"
-            )
         return permutation_montecarlo_shapley(
             u, convergence_check=convergence_check, n_jobs=n_jobs, progress=progress
         )

--- a/src/pydvl/value/shapley/__init__.py
+++ b/src/pydvl/value/shapley/__init__.py
@@ -8,7 +8,7 @@ Please refer to :ref:`data valuation` for an overview of Shapley Data value.
 from typing import Optional, cast
 
 from pydvl.utils import Utility
-from pydvl.value.convergence import StoppingCriterion, max_iterations
+from pydvl.value.stopping import StoppingCriterion, max_iterations
 from pydvl.value.results import ValuationResult
 from pydvl.value.shapley.gt import group_testing_shapley
 from pydvl.value.shapley.knn import knn_shapley

--- a/src/pydvl/value/shapley/__init__.py
+++ b/src/pydvl/value/shapley/__init__.py
@@ -5,10 +5,7 @@ interface to all methods defined in the modules.
 
 Please refer to :ref:`data valuation` for an overview of Shapley Data value.
 """
-from typing import Optional, cast
-
 from pydvl.utils import Utility
-from pydvl.value.stopping import StoppingCriterion, max_iterations
 from pydvl.value.results import ValuationResult
 from pydvl.value.shapley.gt import group_testing_shapley
 from pydvl.value.shapley.knn import knn_shapley
@@ -24,6 +21,7 @@ from pydvl.value.shapley.naive import (
     permutation_exact_shapley,
 )
 from pydvl.value.shapley.types import ShapleyMode
+from pydvl.value.stopping import StoppingCriterion, max_iterations
 
 __all__ = ["compute_shapley_values"]
 

--- a/src/pydvl/value/shapley/__init__.py
+++ b/src/pydvl/value/shapley/__init__.py
@@ -10,6 +10,7 @@ from pydvl.value.result import ValuationResult
 from pydvl.value.shapley.gt import group_testing_shapley
 from pydvl.value.shapley.knn import knn_shapley
 from pydvl.value.shapley.montecarlo import (
+    NoTruncation,
     OwenAlgorithm,
     combinatorial_montecarlo_shapley,
     owen_sampling_shapley,
@@ -104,14 +105,23 @@ def compute_shapley_values(
         raise ValueError(f"Invalid value encountered in {mode=}")
 
     if mode == ShapleyMode.TruncatedMontecarlo:
-        return truncated_montecarlo_shapley(u=u, done=done, n_jobs=n_jobs, **kwargs)
+        truncation = kwargs.pop("truncation", NoTruncation())
+        return truncated_montecarlo_shapley(
+            u=u, done=done, n_jobs=n_jobs, truncation=truncation, **kwargs
+        )
     elif mode == ShapleyMode.CombinatorialMontecarlo:
         return combinatorial_montecarlo_shapley(
             u, done=done, n_jobs=n_jobs, progress=progress
         )
     elif mode == ShapleyMode.PermutationMontecarlo:
+        truncation = kwargs.pop("truncation", NoTruncation())
         return permutation_montecarlo_shapley(
-            u, done=done, n_jobs=n_jobs, progress=progress
+            u,
+            done=done,
+            n_jobs=n_jobs,
+            progress=progress,
+            truncation=truncation,
+            **kwargs,
         )
     elif mode == ShapleyMode.CombinatorialExact:
         return combinatorial_exact_shapley(u, n_jobs=n_jobs, progress=progress)

--- a/src/pydvl/value/shapley/__init__.py
+++ b/src/pydvl/value/shapley/__init__.py
@@ -8,7 +8,7 @@ Please refer to :ref:`data valuation` for an overview of Shapley Data value.
 from typing import Optional, cast
 
 from pydvl.utils import Utility
-from pydvl.value.convergence import ConvergenceCheck, max_iterations
+from pydvl.value.convergence import StoppingCriterion, max_iterations
 from pydvl.value.results import ValuationResult
 from pydvl.value.shapley.gt import group_testing_shapley
 from pydvl.value.shapley.knn import knn_shapley
@@ -102,17 +102,17 @@ def compute_shapley_values(
 
     # FIXME: always require some convergence criteria
 
-    convergence_check = max_iterations(n_iterations)
-    if kwargs.get("convergence_check") is not None:
-        cc = kwargs.pop("convergence_check")
-        if not isinstance(cc, ConvergenceCheck):
-            raise TypeError(f"Expected {cc=} to be of type ConvergenceCheck")
-        convergence_check |= cc
+    stopping_criterion = max_iterations(n_iterations)
+    if kwargs.get("stopping_criterion") is not None:
+        cc = kwargs.pop("stopping_criterion")
+        if not isinstance(cc, StoppingCriterion):
+            raise TypeError(f"Expected {cc=} to be of type StoppingCriterion")
+        stopping_criterion |= cc
 
     if mode == ShapleyMode.TruncatedMontecarlo:
         return truncated_montecarlo_shapley(
             u=u,
-            convergence_check=convergence_check,
+            stopping_criterion=stopping_criterion,
             n_jobs=n_jobs,
             **kwargs,
         )
@@ -126,7 +126,7 @@ def compute_shapley_values(
         )
     elif mode == ShapleyMode.PermutationMontecarlo:
         return permutation_montecarlo_shapley(
-            u, convergence_check=convergence_check, n_jobs=n_jobs, progress=progress
+            u, stopping_criterion=stopping_criterion, n_jobs=n_jobs, progress=progress
         )
     elif mode == ShapleyMode.CombinatorialExact:
         return combinatorial_exact_shapley(u, n_jobs=n_jobs, progress=progress)

--- a/src/pydvl/value/shapley/actor.py
+++ b/src/pydvl/value/shapley/actor.py
@@ -17,8 +17,8 @@ from numpy.typing import NDArray
 from ...utils.config import ParallelConfig
 from ...utils.parallel.actor import Coordinator, RayActorWrapper, Worker
 from ...utils.utility import Utility
-from ...value.results import ValuationResult
-from ..stopping import MaxIterations, StoppingCriterion
+from ...value.result import ValuationResult
+from ..stopping import MaxUpdates, StoppingCriterion
 
 __all__ = ["get_shapley_coordinator", "get_shapley_worker"]
 
@@ -64,13 +64,13 @@ class ShapleyCoordinator(Coordinator):
     def __init__(self, stop: StoppingCriterion):
         super().__init__()
         self.stop = stop
-        self.stop.modify_results = True
+        self.stop.modify_result = True
 
     def accumulate(self) -> ValuationResult:
         """Accumulates all results received from the workers.
 
         :return: Values and standard errors in a
-            :class:`~pydvl.value.results.ValuationResult`. If no worker has
+            :class:`~pydvl.value.result.ValuationResult`. If no worker has
             reported yet, returns ``None``.
         """
         if len(self.worker_results) == 0:
@@ -152,7 +152,7 @@ class ShapleyWorker(Worker):
 
         return _permutation_montecarlo_shapley(
             self.u,
-            stop=MaxIterations(1),
+            stop=MaxUpdates(1),
             permutation_breaker=self.permutation_breaker,
             algorithm_name="truncated_montecarlo_shapley",
         )

--- a/src/pydvl/value/shapley/actor.py
+++ b/src/pydvl/value/shapley/actor.py
@@ -18,7 +18,7 @@ from ...utils.config import ParallelConfig
 from ...utils.parallel.actor import Coordinator, RayActorWrapper, Worker
 from ...utils.utility import Utility
 from ...value.results import ValuationResult
-from ..stopping import StoppingCriterion, max_iterations
+from ..stopping import MaxIterations, StoppingCriterion
 
 __all__ = ["get_shapley_coordinator", "get_shapley_worker"]
 
@@ -64,7 +64,7 @@ class ShapleyCoordinator(Coordinator):
     def __init__(self, stop: StoppingCriterion):
         super().__init__()
         self.stop = stop
-        self.stop.inplace = True
+        self.stop.modify_results = True
 
     def accumulate(self) -> ValuationResult:
         """Accumulates all results received from the workers.
@@ -152,7 +152,7 @@ class ShapleyWorker(Worker):
 
         return _permutation_montecarlo_shapley(
             self.u,
-            stop=max_iterations(1),
+            stop=MaxIterations(1),
             permutation_breaker=self.permutation_breaker,
             algorithm_name="truncated_montecarlo_shapley",
         )

--- a/src/pydvl/value/shapley/actor.py
+++ b/src/pydvl/value/shapley/actor.py
@@ -18,7 +18,7 @@ from pydvl.utils.parallel.actor import Coordinator, RayActorWrapper, Worker
 from pydvl.utils.utility import Utility
 from pydvl.value.result import ValuationResult
 from pydvl.value.shapley.types import PermutationBreaker
-from pydvl.value.stopping import MaxUpdates, StoppingCriterion
+from pydvl.value.stopping import MaxChecks, StoppingCriterion
 
 __all__ = ["get_shapley_coordinator", "get_shapley_worker"]
 
@@ -145,7 +145,7 @@ class ShapleyWorker(Worker):
 
         return _permutation_montecarlo_shapley(
             self.u,
-            done=MaxUpdates(1),
+            done=MaxChecks(1),
             permutation_breaker=self.permutation_breaker,
             algorithm_name=self.algorithm,
         )

--- a/src/pydvl/value/shapley/actor.py
+++ b/src/pydvl/value/shapley/actor.py
@@ -13,11 +13,11 @@ from typing import Optional, cast
 
 import numpy as np
 
-from .types import PermutationBreaker
 from pydvl.utils.config import ParallelConfig
 from pydvl.utils.parallel.actor import Coordinator, RayActorWrapper, Worker
 from pydvl.utils.utility import Utility
 from pydvl.value.result import ValuationResult
+from pydvl.value.shapley.types import PermutationBreaker
 from pydvl.value.stopping import MaxUpdates, StoppingCriterion
 
 __all__ = ["get_shapley_coordinator", "get_shapley_worker"]

--- a/src/pydvl/value/shapley/actor.py
+++ b/src/pydvl/value/shapley/actor.py
@@ -74,7 +74,7 @@ class ShapleyCoordinator(Coordinator):
             reported yet, returns ``None``.
         """
         if len(self.worker_results) == 0:
-            return ValuationResult()
+            return ValuationResult.empty()
 
         # FIXME: inefficient, possibly unstable
         totals: ValuationResult = reduce(operator.add, self.worker_results)

--- a/src/pydvl/value/shapley/actor.py
+++ b/src/pydvl/value/shapley/actor.py
@@ -162,7 +162,7 @@ class ShapleyWorker(Worker):
         :meth:`~pydvl.utils.parallel.actor.Coordinator.is_done` flag,
         terminating if it's ``True``.
         """
-        acc = None
+        acc = ValuationResult().empty()
         while not self.coordinator.is_done():
             start_time = time()
             while (time() - start_time) < self.update_period:
@@ -173,5 +173,5 @@ class ShapleyWorker(Worker):
                         RuntimeWarning,
                     )
                     continue
-                acc = results if acc is None else acc + results
+                acc += results
             self.coordinator.add_results(acc)

--- a/src/pydvl/value/shapley/actor.py
+++ b/src/pydvl/value/shapley/actor.py
@@ -18,7 +18,6 @@ from ...utils.config import ParallelConfig
 from ...utils.parallel.actor import Coordinator, RayActorWrapper, Worker
 from ...utils.status import Status
 from ...utils.utility import Utility
-
 from ...value.results import ValuationResult
 from ..convergence import ConvergenceCheck, max_iterations
 from .types import PermutationBreaker

--- a/src/pydvl/value/shapley/actor.py
+++ b/src/pydvl/value/shapley/actor.py
@@ -61,10 +61,10 @@ class ShapleyCoordinator(Coordinator):
     satisfied.
     """
 
-    def __init__(self, stop: StoppingCriterion):
+    def __init__(self, done: StoppingCriterion):
         super().__init__()
-        self.stop = stop
-        self.stop.modify_result = True
+        self.results_done = done
+        self.results_done.modify_result = True
 
     def accumulate(self) -> ValuationResult:
         """Accumulates all results received from the workers.
@@ -93,7 +93,7 @@ class ShapleyCoordinator(Coordinator):
         if self.is_done():
             return True
         if len(self.worker_results) > 0:
-            self._status = self.stop(self.accumulate())
+            self._status = self.results_done(self.accumulate())
         return self.is_done()
 
 
@@ -152,7 +152,7 @@ class ShapleyWorker(Worker):
 
         return _permutation_montecarlo_shapley(
             self.u,
-            stop=MaxUpdates(1),
+            done=MaxUpdates(1),
             permutation_breaker=self.permutation_breaker,
             algorithm_name="truncated_montecarlo_shapley",
         )

--- a/src/pydvl/value/shapley/actor.py
+++ b/src/pydvl/value/shapley/actor.py
@@ -61,10 +61,10 @@ class ShapleyCoordinator(Coordinator):
     satisfied.
     """
 
-    def __init__(self, stopping_criterion: StoppingCriterion):
+    def __init__(self, stop: StoppingCriterion):
         super().__init__()
-        self.stopping_criterion = stopping_criterion
-        self.stopping_criterion.inplace = True
+        self.stop = stop
+        self.stop.inplace = True
 
     def accumulate(self) -> ValuationResult:
         """Accumulates all results received from the workers.
@@ -93,7 +93,7 @@ class ShapleyCoordinator(Coordinator):
         if self.is_done():
             return True
         if len(self.worker_results) > 0:
-            self._status = self.stopping_criterion(self.accumulate())
+            self._status = self.stop(self.accumulate())
         return self.is_done()
 
 

--- a/src/pydvl/value/shapley/actor.py
+++ b/src/pydvl/value/shapley/actor.py
@@ -18,8 +18,7 @@ from ...utils.config import ParallelConfig
 from ...utils.parallel.actor import Coordinator, RayActorWrapper, Worker
 from ...utils.utility import Utility
 from ...value.results import ValuationResult
-from ..convergence import StoppingCriterion, max_iterations
-from .types import PermutationBreaker
+from ..stopping import StoppingCriterion, max_iterations
 
 __all__ = ["get_shapley_coordinator", "get_shapley_worker"]
 
@@ -153,7 +152,7 @@ class ShapleyWorker(Worker):
 
         return _permutation_montecarlo_shapley(
             self.u,
-            stopping_criterion=max_iterations(1),
+            stop=max_iterations(1),
             permutation_breaker=self.permutation_breaker,
             algorithm_name="truncated_montecarlo_shapley",
         )

--- a/src/pydvl/value/shapley/actor.py
+++ b/src/pydvl/value/shapley/actor.py
@@ -162,7 +162,7 @@ class ShapleyWorker(Worker):
         terminating if it's ``True``.
         """
         while True:
-            acc = ValuationResult(algorithm=self.algorithm)
+            acc = ValuationResult.empty(algorithm=self.algorithm)
             start_time = time()
             while (time() - start_time) < self.update_period:
                 if self.coordinator.is_done():

--- a/src/pydvl/value/shapley/actor.py
+++ b/src/pydvl/value/shapley/actor.py
@@ -74,7 +74,7 @@ class ShapleyCoordinator(Coordinator):
             reported yet, returns ``None``.
         """
         if len(self.worker_results) == 0:
-            return ValuationResult.empty()
+            return ValuationResult()
 
         # FIXME: inefficient, possibly unstable
         totals: ValuationResult = reduce(operator.add, self.worker_results)
@@ -102,6 +102,8 @@ class ShapleyWorker(Worker):
 
     It should work.
     """
+
+    algorithm: str = "truncated_montecarlo_shapley"
 
     def __init__(
         self,
@@ -145,7 +147,7 @@ class ShapleyWorker(Worker):
             self.u,
             done=MaxUpdates(1),
             permutation_breaker=self.permutation_breaker,
-            algorithm_name="truncated_montecarlo_shapley",
+            algorithm_name=self.algorithm,
         )
 
     def run(self, *args, **kwargs):
@@ -160,7 +162,7 @@ class ShapleyWorker(Worker):
         terminating if it's ``True``.
         """
         while True:
-            acc = ValuationResult.empty()
+            acc = ValuationResult(algorithm=self.algorithm)
             start_time = time()
             while (time() - start_time) < self.update_period:
                 if self.coordinator.is_done():

--- a/src/pydvl/value/shapley/actor.py
+++ b/src/pydvl/value/shapley/actor.py
@@ -150,6 +150,7 @@ class ShapleyWorker(Worker):
 
         return _permutation_montecarlo_shapley(
             self.u,
+            convergence_check=max_iterations(1),
             permutation_breaker=self.permutation_breaker,
             algorithm_name="truncated_montecarlo_shapley",
         )

--- a/src/pydvl/value/shapley/gt.py
+++ b/src/pydvl/value/shapley/gt.py
@@ -320,7 +320,6 @@ def group_testing_shapley(
             algorithm="group_testing_shapley",
             status=Status.Converged,
             values=result.x,
-            stderr=None,
             data_names=u.data.data_names,
         )
     else:
@@ -328,6 +327,5 @@ def group_testing_shapley(
             algorithm="group_testing_shapley",
             status=Status.Failed,
             values=np.nan * np.ones_like(u.data.indices),
-            stderr=None,
             data_names=u.data.data_names,
         )

--- a/src/pydvl/value/shapley/knn.py
+++ b/src/pydvl/value/shapley/knn.py
@@ -12,7 +12,7 @@ from sklearn.neighbors import KNeighborsClassifier, NearestNeighbors
 
 from pydvl.utils import Utility, maybe_progress
 from pydvl.utils.status import Status
-from pydvl.value.results import ValuationResult
+from pydvl.value.result import ValuationResult
 
 __all__ = ["knn_shapley"]
 

--- a/src/pydvl/value/shapley/knn.py
+++ b/src/pydvl/value/shapley/knn.py
@@ -80,6 +80,5 @@ def knn_shapley(u: Utility, *, progress: bool = True) -> ValuationResult:
         algorithm="knn_shapley",
         status=Status.Converged,
         values=values,
-        stderr=None,
         data_names=u.data.data_names,
     )

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -327,10 +327,8 @@ def _combinatorial_montecarlo_shapley(
         subset = np.setxor1d(u.data.indices, [idx], assume_unique=True)
         s = next(random_powerset(subset, n_samples=1))
         marginal = (u({idx}.union(s)) - u(s)) / math.comb(n - 1, len(s))
-        result.update(idx, marginal)
+        result.update(idx, correction * marginal)
 
-    result.values[:] = result.values * correction
-    result.variances[:] = result.variances * correction**2
     return result
 
 

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -53,7 +53,6 @@ from pydvl.utils.utility import Utility
 from pydvl.value.result import ValuationResult
 from pydvl.value.stopping import StoppingCriterion
 
-
 logger = logging.getLogger(__name__)
 
 __all__ = [

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -50,7 +50,7 @@ from ...utils.parallel import MapReduceJob, init_parallel_backend
 from ...utils.progress import maybe_progress
 from ...utils.status import Status
 from ...utils.utility import Utility
-from ..convergence import StoppingCriterion
+from ..stopping import StoppingCriterion
 from ..results import ValuationResult
 from .actor import get_shapley_coordinator, get_shapley_worker
 from .types import PermutationBreaker

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -213,8 +213,7 @@ def _permutation_montecarlo_shapley(
     :param job_id: id to use for reporting progress (e.g. to place progres bars)
     :return: An object with the results
     """
-    n = len(u.data)
-    result = ValuationResult(algorithm=algorithm_name, indices=u.data.indices)
+    result = ValuationResult.empty(algorithm=algorithm_name, indices=u.data.indices)
 
     pbar = tqdm(disable=not progress, position=job_id, total=100, unit="%")
     while not done(result):
@@ -312,7 +311,7 @@ def _combinatorial_montecarlo_shapley(
     # powerset of a set with n-1 elements has mass 2^{n-1} over each subset. The
     # additional factor n corresponds to the one in the Shapley definition
     correction = 2 ** (n - 1) / n
-    result = ValuationResult(
+    result = ValuationResult.empty(
         algorithm="combinatorial_montecarlo_shapley", indices=indices
     )
 

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -214,7 +214,7 @@ def _permutation_montecarlo_shapley(
     :return: An object with the results
     """
     n = len(u.data)
-    result = ValuationResult.empty(algorithm_name, n)
+    result = ValuationResult(algorithm=algorithm_name, indices=u.data.indices)
 
     pbar = tqdm(disable=not progress, position=job_id, total=100, unit="%")
     while not done(result):
@@ -307,16 +307,14 @@ def _combinatorial_montecarlo_shapley(
     """
     n = len(u.data)
 
-    if len(np.unique(indices)) != len(indices):
-        raise ValueError("Repeated indices passed")
-
     # Correction coming from Monte Carlo integration so that the mean of the
     # marginals converges to the value: the uniform distribution over the
     # powerset of a set with n-1 elements has mass 2^{n-1} over each subset. The
     # additional factor n corresponds to the one in the Shapley definition
     correction = 2 ** (n - 1) / n
-    variances = np.zeros(shape=n)
-    result = ValuationResult.empty("combinatorial_montecarlo_shapley", n)
+    result = ValuationResult(
+        algorithm="combinatorial_montecarlo_shapley", indices=indices
+    )
 
     repeat_indices = takewhile(lambda _: not done(result), cycle(indices))
     pbar = tqdm(disable=not progress, position=job_id, total=100, unit="%")

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -207,6 +207,7 @@ def _permutation_montecarlo_shapley(
 
         # FIXME: shoe-horning convergence check into this function is bad
         result += ValuationResult(
+            algorithm=algorithm_name,
             values=values,
             stderr=np.sqrt(variances / np.maximum(1, counts)),
             counts=counts,
@@ -257,7 +258,6 @@ def permutation_montecarlo_shapley(
             permutation_breaker=permutation_breaker,
             progress=progress,
         ),
-        reduce_kwargs=dict(axis=0),
         config=config,
         n_jobs=n_jobs,
     )

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -430,7 +430,7 @@ def _owen_sampling_shapley(
         algorithm="owen_sampling_shapley_" + str(method),
         values=values,
         stderr=np.zeros_like(values),
-        counts=np.ones_like(values),
+        counts=np.ones_like(values, dtype=np.int_),
     )
 
 

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -374,7 +374,7 @@ def combinatorial_montecarlo_shapley(
     map_reduce_job: MapReduceJob[NDArray, ValuationResult] = MapReduceJob(
         u.data.indices,
         map_func=_combinatorial_montecarlo_shapley,
-        reduce_func=lambda results: reduce(operator.or_, results),
+        reduce_func=lambda results: reduce(operator.add, results),
         map_kwargs=dict(u=u, stop=stop, progress=progress),
         n_jobs=n_jobs,
         config=config,
@@ -513,7 +513,7 @@ def owen_sampling_shapley(
     map_reduce_job: MapReduceJob[NDArray, ValuationResult] = MapReduceJob(
         u.data.indices,
         map_func=_owen_sampling_shapley,
-        reduce_func=lambda results: reduce(operator.or_, results),
+        reduce_func=lambda results: reduce(operator.add, results),
         map_kwargs=dict(
             u=u,
             method=OwenAlgorithm(method),

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -50,7 +50,7 @@ from pydvl.utils.parallel import MapReduceJob, init_parallel_backend
 from pydvl.utils.progress import maybe_progress
 from pydvl.utils.status import Status
 from pydvl.utils.utility import Utility
-from pydvl.value.results import ValuationResult
+from pydvl.value.result import ValuationResult
 from pydvl.value.stopping import StoppingCriterion
 
 from .actor import get_shapley_coordinator, get_shapley_worker
@@ -111,13 +111,11 @@ def truncated_montecarlo_shapley(
     :param n_jobs: number of jobs processing permutations. If None, it will be
         set to :func:`available_cpus`.
     :param config: Object configuring parallel computation, with cluster
-    address,
-        number of cpus, etc.
+        address, number of cpus, etc.
     :param coordinator_update_period: in seconds. Check status with the job
         coordinator every so often.
     :param worker_update_period: interval in seconds between different
-    updates to
-        and from the coordinator
+        updates to and from the coordinator
     :return: Object with the data values.
 
     """
@@ -199,10 +197,7 @@ def _permutation_montecarlo_shapley(
     variances = np.zeros_like(values)
     counts = np.zeros(shape=n, dtype=np.int_)
     result = ValuationResult(
-        algorithm=algorithm_name,
-        values=values,
-        stderr=stderr,
-        counts=counts,
+        algorithm=algorithm_name, values=values, stderr=stderr, counts=counts
     )
     for _ in maybe_progress(count(), progress, position=job_id):  # infinite loop
         prev_score = 0.0
@@ -252,8 +247,7 @@ def permutation_montecarlo_shapley(
     :param stop: function checking whether computation must stop.
     :param n_jobs: number of jobs across which to distribute the computation.
     :param config: Object configuring parallel computation, with cluster
-    address,
-        number of cpus, etc.
+        address, number of cpus, etc.
     :param progress: Whether to display progress bars for each job.
     :return: Object with the data values.
     """
@@ -432,7 +426,7 @@ def _owen_sampling_shapley(
         e = np.zeros(max_q)
         subset = np.array(list(index_set.difference({i})))
         for j, q in enumerate(q_steps):
-            for s in random_powerset(subset, max_subsets=n_iterations, q=q):
+            for s in random_powerset(subset, n_samples=n_iterations, q=q):
                 marginal = u({i}.union(s)) - u(s)
                 if method == OwenAlgorithm.Antithetic and q != 0.5:
                     s_complement = index_set.difference(s)
@@ -475,15 +469,19 @@ def owen_sampling_shapley(
     using one of two methods. The first one, selected with the argument ``mode =
     OwenAlgorithm.Standard``, approximates the integral with:
 
-    $$\hat{v}_u(i) = \frac{1}{Q M} \sum_{j=0}^Q \sum_{m=1}^M [u(S^{(q_j)}_m \cup \{i\}) - u(S^{(q_j)}_m)],$$
+    $$\hat{v}_u(i) = \frac{1}{Q M} \sum_{j=0}^Q \sum_{m=1}^M [u(S^{(q_j)}_m
+    \cup \{i\}) - u(S^{(q_j)}_m)],$$
 
     where $q_j = \frac{j}{Q} \in [0,1]$ and the sets $S^{(q_j)}$ are such that a
     sample $x \in S^{(q_j)}$ if a draw from a $Ber(q_j)$ distribution is 1.
 
-    The second method, selected with the argument ``mode = OwenAlgorithm.Anthithetic``,
+    The second method, selected with the argument ``mode =
+    OwenAlgorithm.Anthithetic``,
     uses correlated samples in the inner sum to reduce the variance:
 
-    $$\hat{v}_u(i) = \frac{1}{Q M} \sum_{j=0}^Q \sum_{m=1}^M [u(S^{(q_j)}_m \cup \{i\}) - u(S^{(q_j)}_m) + u((S^{(q_j)}_m)^c \cup \{i\}) - u((S^{(q_j)}_m)^c)],$$
+    $$\hat{v}_u(i) = \frac{1}{Q M} \sum_{j=0}^Q \sum_{m=1}^M [u(S^{(q_j)}_m
+    \cup \{i\}) - u(S^{(q_j)}_m) + u((S^{(q_j)}_m)^c \cup \{i\}) - u((S^{(
+    q_j)}_m)^c)],$$
 
     where now $q_j = \frac{j}{2Q} \in [0,\frac{1}{2}]$, and $S^c$ is the
     complement of $S$.

--- a/src/pydvl/value/shapley/naive.py
+++ b/src/pydvl/value/shapley/naive.py
@@ -8,7 +8,7 @@ from numpy.typing import NDArray
 
 from pydvl.utils import MapReduceJob, ParallelConfig, Utility, maybe_progress, powerset
 from pydvl.utils.status import Status
-from pydvl.value.results import ValuationResult
+from pydvl.value.result import ValuationResult
 
 __all__ = ["permutation_exact_shapley", "combinatorial_exact_shapley"]
 

--- a/src/pydvl/value/shapley/naive.py
+++ b/src/pydvl/value/shapley/naive.py
@@ -54,7 +54,6 @@ def permutation_exact_shapley(u: Utility, *, progress: bool = True) -> Valuation
         algorithm="permutation_exact_shapley",
         status=Status.Converged,
         values=values,
-        stderr=None,
         data_names=u.data.data_names,
     )
 
@@ -131,6 +130,5 @@ def combinatorial_exact_shapley(
         algorithm="combinatorial_exact_shapley",
         status=Status.Converged,
         values=values,
-        stderr=None,
         data_names=u.data.data_names,
     )

--- a/src/pydvl/value/shapley/types.py
+++ b/src/pydvl/value/shapley/types.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Protocol
 
 import numpy as np
-from numpy._typing import NDArray
+from numpy.typing import NDArray
 
 
 class ShapleyMode(str, Enum):

--- a/src/pydvl/value/shapley/types.py
+++ b/src/pydvl/value/shapley/types.py
@@ -1,8 +1,4 @@
 from enum import Enum
-from typing import Protocol
-
-import numpy as np
-from numpy.typing import NDArray
 
 
 class ShapleyMode(str, Enum):
@@ -21,15 +17,3 @@ class ShapleyMode(str, Enum):
     PermutationExact = "permutation_exact"
     PermutationMontecarlo = "permutation_montecarlo"
     TruncatedMontecarlo = "truncated_montecarlo"
-
-
-class PermutationBreaker(Protocol):
-    def __call__(self, idx: int, marginals: NDArray[np.float_]) -> bool:
-        ...
-
-
-class ValueStopper(Protocol):
-    def __call__(
-        self, marginals: NDArray[np.float_], variances: NDArray[np.float_]
-    ) -> bool:
-        ...

--- a/src/pydvl/value/stopping.py
+++ b/src/pydvl/value/stopping.py
@@ -3,6 +3,7 @@ from time import time
 from typing import Callable, Optional, Type
 
 import numpy as np
+from numpy.typing import NDArray
 
 from pydvl.utils import Status
 from pydvl.value import ValuationResult
@@ -234,6 +235,9 @@ class HistoryDeviation(StoppingCriterion):
     :param pin_converged: If ``True``, once an index has converged, it is pinned
     """
 
+    memory: NDArray[np.float_]
+    checked: NDArray[np.bool_]
+
     def __init__(
         self,
         n_steps: int,
@@ -250,8 +254,8 @@ class HistoryDeviation(StoppingCriterion):
         self.n_steps = n_steps
         self.rtol = rtol
         self.pin_converged = pin_converged
-        self.memory = None
-        self.checked = None
+        self.memory = None  # type: ignore
+        self.checked = None  # type: ignore
 
     def check(self, r: ValuationResult) -> Status:
         if self.memory is None:

--- a/src/pydvl/value/stopping.py
+++ b/src/pydvl/value/stopping.py
@@ -1,33 +1,40 @@
 from functools import update_wrapper
-from typing import Callable, Optional, cast
+from time import time
+from typing import Callable, Optional, Type
 
 import numpy as np
 
 from pydvl.utils import Status
 from pydvl.value import ValuationResult
 
-__all__ = ["StoppingCriterion", "median_ratio", "max_iterations", "history_deviation"]
+__all__ = [
+    "make_criterion",
+    "StoppingCriterion",
+    "MedianRatio",
+    "MaxIterations",
+    "MaxTime",
+    "HistoryDeviation",
+]
 
 StoppingCriterionCallable = Callable[[ValuationResult], Status]
 
 
 class StoppingCriterion:
-    _fun: StoppingCriterionCallable
+    def __init__(self, modify_results: bool = True):
+        """A composable callable object to determine whether a computation
+        must stop.
 
-    def __init__(self, fun: StoppingCriterionCallable, inplace: bool = True):
-        """A composable callable object to determine whether a computation must stop.
-
-        ``StoppingCriterion``s take a :class:`~pydvl.value.results.ValuationResult`
+        ``StoppingCriterion``s take a
+        :class:`~pydvl.value.results.ValuationResult`
         and return a :class:`~pydvl.value.results.Status~.
 
         :Creating StoppingCriterions:
 
-        The easiest way is to declare a function implementing the
-        interface :ref:`StoppingCriterionCallable` and wrap it with this class
-
-        For more realistic examples see
-        e.g. :func:`~pydvl.value.stopping.median_ratio`
-        or :func:`~pydvl.value.stopping.history_deviation`
+        The easiest way is to declare a function implementing the interface
+        :ref:`StoppingCriterionCallable` and wrap it with an instance
+        of this class. Alternatively, one can inherit from this class. For some
+        examples see e.g. :func:`~pydvl.value.stopping.MedianRation` and
+        :func:`~pydvl.value.stopping.HistoryDeviation`
 
         :Composing stopping criteria:
 
@@ -39,20 +46,21 @@ class StoppingCriterion:
         :param fun: A callable to wrap into a composable object. Use this to
             enable simpler functions to be composed with the operators described
             above.
-        :param inplace: If ``True`` the status of the input ValuationResult is
-            modified in place.
+        :param modify_results: If ``True`` the status of the input
+            :class:`~pydvl.value.results.ValuationResult` is modified in place.
         """
-        self.inplace = inplace
-        self._fun = fun
-        update_wrapper(self, self._fun)
+        self.modify_results = modify_results
+
+    def check(self, results: ValuationResult) -> Status:
+        raise NotImplementedError
 
     @property
     def name(self):
-        return self._fun.__name__
+        return type(self).__name__
 
     def __call__(self, results: ValuationResult) -> Status:
-        status = self._fun(results)
-        if self.inplace:  # FIXME: this is not nice
+        status = self.check(results)
+        if self.modify_results:  # FIXME: this is not nice
             results._status = status
         return status
 
@@ -61,21 +69,25 @@ class StoppingCriterion:
             return self(results) & other(results)
 
         fun.__name__ = f"Composite StoppingCriterion: {self.name} AND {other.name}"
-        return StoppingCriterion(cast(StoppingCriterionCallable, fun))
+        return make_criterion(fun)(
+            modify_results=self.modify_results or other.modify_results
+        )
 
     def __or__(self, other: "StoppingCriterion") -> "StoppingCriterion":
         def fun(results: ValuationResult):
             return self(results) | other(results)
 
         fun.__name__ = f"Composite StoppingCriterion: {self.name} OR {other.name}"
-        return StoppingCriterion(cast(StoppingCriterionCallable, fun))
+        return make_criterion(fun)(
+            modify_results=self.modify_results or other.modify_results
+        )
 
     def __invert__(self) -> "StoppingCriterion":
         def fun(results: ValuationResult):
             return ~self(results)
 
         fun.__name__ = f"Composite StoppingCriterion: NOT {self.name}"
-        return StoppingCriterion(cast(StoppingCriterionCallable, fun))
+        return make_criterion(fun)(modify_results=self.modify_results)
 
     def __xor__(self, other: "StoppingCriterion") -> "StoppingCriterion":
         def fun(results: ValuationResult):
@@ -84,57 +96,97 @@ class StoppingCriterion:
             return (a & ~b) | (~a & b)
 
         fun.__name__ = f"Composite StoppingCriterion: {self.name} XOR {other.name}"
-        return StoppingCriterion(cast(StoppingCriterionCallable, fun))
+        return make_criterion(fun)(
+            modify_results=self.modify_results or other.modify_results
+        )
 
 
-def median_ratio(threshold: float) -> StoppingCriterion:
-    """Ratio of medians for convergence.
+def make_criterion(fun: StoppingCriterionCallable) -> Type[StoppingCriterion]:
+    """Create a new :class:`StoppingCriterion` from a function."""
+
+    class WrappedCriterion(StoppingCriterion):
+        def __init__(self, modify_results: bool = True):
+            super().__init__(modify_results=modify_results)
+            self.check = fun
+            update_wrapper(self, self.check)
+
+        @property
+        def name(self):
+            return fun.__name__
+
+    return WrappedCriterion
+
+
+class MedianRatio(StoppingCriterion):
+    """Compute a ratio of median errors to values to determine convergence.
 
     :param threshold: Converged if the ratio of median standard
         error to median of value has dropped below this value.
-    :return: The convergence check
     """
 
-    def median_ratio_check(results: ValuationResult) -> Status:
+    def __init__(self, threshold: float, modify_results: bool = True):
+        super().__init__(modify_results=modify_results)
+        self.threshold = threshold
+
+    def check(self, results: ValuationResult) -> Status:
         ratio = np.median(results.stderr) / np.median(results.values)
-        if ratio < threshold:
+        if ratio < self.threshold:
             return Status.Converged
         return Status.Pending
 
-    return StoppingCriterion(median_ratio_check)
 
-
-def max_iterations(n_iterations: Optional[int]) -> StoppingCriterion:
-    """Terminate if the number of iterations exceeds the given number.
+class MaxIterations(StoppingCriterion):
+    """Terminate if the number of value updates exceeds the given number.
 
     This checks the ``counts`` field of a
-    :class:`~pydvl.value.results.ValuationResult`. For powerset samplers, the
-    maximum number of times that a particular index has been updated coincides
-    with the maximum number of subsets sampled. For permutation samplers, it
-    coincides with the number of permutations sampled.
+    :class:`~pydvl.value.results.ValuationResult`, i.e. the number of times that
+    each index has been updated. For powerset samplers, the maximum of this
+    number coincides with the maximum number of subsets sampled. For
+    permutation samplers, it coincides with the number of permutations sampled.
 
-    :param n_iterations: threshold. If ``None``, no check is performed,
-        effectively creating a convergence check that always returns ``Pending``.
-    :return: The convergence check
+    :param n_iterations: Threshold: if ``None``, no check is performed,
+        effectively creating a (never) stopping criterion that always returns
+        ``Pending``.
     """
-    if n_iterations is None:
-        return StoppingCriterion(lambda _: Status.Pending)
 
-    _max_iterations = n_iterations
+    def __init__(self, n_iterations: Optional[int], modify_results: bool = True):
+        self.n_iterations = n_iterations
+        super().__init__(modify_results=modify_results)
 
-    def max_iterations_check(results: ValuationResult) -> Status:
-        try:
-            if np.max(results.counts) > _max_iterations:
-                return Status.Converged
-        except AttributeError:
-            raise ValueError("ValuationResult didn't contain a `counts` attribute")
+    def check(self, results: ValuationResult) -> Status:
+        if self.n_iterations is not None:
+            try:
+                if np.max(results.counts) > self.n_iterations:
+                    return Status.Converged
+            except AttributeError:
+                raise ValueError("ValuationResult didn't contain a `counts` attribute")
 
         return Status.Pending
 
-    return StoppingCriterion(max_iterations_check)
+
+class MaxTime(StoppingCriterion):
+    """Terminate if the computation time exceeds the given number of seconds.
+
+    Checks the elapsed time since construction
+
+    :param seconds: Threshold: The computation is terminated if the elapsed time
+        between object construction and a check exceeds this value. If ``None``,
+        no check is performed, effectively creating a (never) stopping criterion
+        that always returns ``Pending``.
+    """
+
+    def __init__(self, seconds: Optional[float], modify_results: bool = True):
+        super().__init__(modify_results=modify_results)
+        self.max_seconds = seconds
+        self.start = time()
+
+    def check(self, results: ValuationResult) -> Status:
+        if self.max_seconds is not None and time() > self.start + self.max_seconds:
+            return Status.Converged
+        return Status.Pending
 
 
-def history_deviation(n_samples: int, n_steps: int, rtol: float) -> StoppingCriterion:
+class HistoryDeviation(StoppingCriterion):
     """Ghorbani et al.'s check for relative distance to a previous step in the
      computation.
 
@@ -147,31 +199,33 @@ def history_deviation(n_samples: int, n_steps: int, rtol: float) -> StoppingCrit
     :param n_steps: Checkpoint values every so many updates and use these saved
         values to compare.
     :param rtol: Relative tolerance for convergence.
-    :return: The convergence check
     """
-    # Yuk... using static vars just to avoid nonlocal
-    # An abstract class and maybe a factory would probably be better
-    def history_deviation_check(r: ValuationResult) -> Status:
+
+    def __init__(
+        self, n_samples: int, n_steps: int, rtol: float, modify_results: bool = True
+    ):
+        super().__init__(modify_results=modify_results)
+        self.n_samples = n_samples
+        self.n_steps = n_steps
+        self.rtol = rtol
+        self.memory = np.zeros(n_samples)
+        self.converged = np.array([False] * n_samples)
+
+    def check(self, r: ValuationResult) -> Status:
         if r.counts.max() == 0:  # safeguard against reuse of the criterion
-            history_deviation_check.memory = np.zeros(n_samples)
-            history_deviation_check.converged = np.array([False] * n_samples)
+            self.memory = np.zeros(self.n_samples)
+            self.converged = np.array([False] * self.n_samples)
             return Status.Pending
         # Look at indices that have been updated n_steps times since last save
         # For permutation samplers, this should be all indices, every n_steps
-        ii = np.where(r.counts % n_steps == 0)
+        ii = np.where(r.counts % self.n_steps == 0)
         if len(ii) > 0:
             if (
-                np.abs(
-                    (r.values[ii] - history_deviation_check.memory[ii]) / r.values[ii]
-                ).mean()
-                < rtol
+                np.abs((r.values[ii] - self.memory[ii]) / r.values[ii]).mean()
+                < self.rtol
             ):
-                history_deviation_check.converged[ii] = True
-                if np.all(history_deviation_check.converged):
+                self.converged[ii] = True
+                if np.all(self.converged):
                     return Status.Converged
-            history_deviation_check.memory[ii] = r.values[ii]
+            self.memory[ii] = r.values[ii]
         return Status.Pending
-
-    history_deviation_check.memory = np.zeros(n_samples)
-    history_deviation_check.converged = np.array([False] * n_samples)
-    return StoppingCriterion(history_deviation_check)

--- a/src/pydvl/value/stopping.py
+++ b/src/pydvl/value/stopping.py
@@ -43,7 +43,9 @@ __all__ = [
     "make_criterion",
     "StoppingCriterion",
     "StandardError",
+    "MaxChecks",
     "MaxUpdates",
+    "MinUpdates",
     "MaxTime",
     "HistoryDeviation",
 ]

--- a/src/pydvl/value/stopping.py
+++ b/src/pydvl/value/stopping.py
@@ -134,7 +134,7 @@ def max_iterations(n_iterations: Optional[int]) -> StoppingCriterion:
     return StoppingCriterion(max_iterations_check)
 
 
-def history_deviation(n_samples: int, n_steps: int, atol: float) -> StoppingCriterion:
+def history_deviation(n_samples: int, n_steps: int, rtol: float) -> StoppingCriterion:
     """Ghorbani et al.'s check for relative distance to a previous step in the
      computation.
 
@@ -146,7 +146,7 @@ def history_deviation(n_samples: int, n_steps: int, atol: float) -> StoppingCrit
     :param n_samples: Number of values in the result objects.
     :param n_steps: Checkpoint values every so many updates and use these saved
         values to compare.
-    :param atol: Absolute tolerance for convergence.
+    :param rtol: Relative tolerance for convergence.
     :return: The convergence check
     """
     # Yuk... using static vars just to avoid nonlocal
@@ -164,7 +164,7 @@ def history_deviation(n_samples: int, n_steps: int, atol: float) -> StoppingCrit
                 np.abs(
                     (r.values[ii] - history_deviation_check.memory[ii]) / r.values[ii]
                 ).mean()
-                < atol
+                < rtol
             ):
                 history_deviation_check.converged[ii] = True
                 if np.all(history_deviation_check.converged):

--- a/src/pydvl/value/stopping.py
+++ b/src/pydvl/value/stopping.py
@@ -26,10 +26,10 @@ class StoppingCriterion:
         interface :ref:`StoppingCriterionCallable` and wrap it with this class
 
         For more realistic examples see
-        e.g. :func:`~pydvl.value.convergence.median_ratio`
-        or :func:`~pydvl.value.convergence.history_deviation`
+        e.g. :func:`~pydvl.value.stopping.median_ratio`
+        or :func:`~pydvl.value.stopping.history_deviation`
 
-        :Composing StoppingCriterions:
+        :Composing stopping criteria:
 
         Objects of this type can be composed with the binary operators ``&``
         (_and_), ``^`` (_xor_) and ``|`` (_or_),

--- a/src/pydvl/value/stopping.py
+++ b/src/pydvl/value/stopping.py
@@ -1,3 +1,4 @@
+import abc
 from functools import update_wrapper
 from time import time
 from typing import Callable, Optional, Type
@@ -11,7 +12,7 @@ from pydvl.value import ValuationResult
 __all__ = [
     "make_criterion",
     "StoppingCriterion",
-    "MedianRatio",
+    "StandardError",
     "MaxUpdates",
     "MaxTime",
     "HistoryDeviation",
@@ -20,7 +21,7 @@ __all__ = [
 StoppingCriterionCallable = Callable[[ValuationResult], Status]
 
 
-class StoppingCriterion:
+class StoppingCriterion(abc.ABC):
     def __init__(self, modify_result: bool = True):
         """A composable callable object to determine whether a computation
         must stop.
@@ -39,59 +40,92 @@ class StoppingCriterion:
         :Composing stopping criteria:
 
         Objects of this type can be composed with the binary operators ``&``
-        (_and_), ``^`` (_xor_) and ``|`` (_or_),
-        see :class:`~pydvl.utils.status.Status` for the truth tables. The unary
-        operator ``~`` (_not_) is also supported.
+        (_and_), and ``|`` (_or_), see :class:`~pydvl.utils.status.Status` for
+        the truth tables. The unary operator ``~`` (_not_) is also supported.
 
-        :param fun: A callable to wrap into a composable object. Use this to
-            enable simpler functions to be composed with the operators described
-            above.
         :param modify_result: If ``True`` the status of the input
             :class:`~pydvl.value.result.ValuationResult` is modified in place.
         """
         self.modify_result = modify_result
 
+    @abc.abstractmethod
     def check(self, result: ValuationResult) -> Status:
-        raise NotImplementedError
+        """Check whether the computation should stop."""
+        ...
+
+    @abc.abstractmethod
+    def completion(self) -> float:
+        """Returns a value between 0 and 1 indicating the completion of the
+        computation.
+        """
+        ...
 
     @property
     def name(self):
         return type(self).__name__
 
     def __call__(self, result: ValuationResult) -> Status:
+        if result.status is not Status.Pending:
+            return result.status
         status = self.check(result)
         if self.modify_result:  # FIXME: this is not nice
             result._status = status
         return status
 
     def __and__(self, other: "StoppingCriterion") -> "StoppingCriterion":
-        def fun(result: ValuationResult):
-            return self(result) & other(result)
+        class CompositeCriterion(StoppingCriterion):
+            def check(self, result: ValuationResult) -> Status:
+                return self(result) & other(result)
 
-        fun.__name__ = f"Composite StoppingCriterion: {self.name} AND {other.name}"
-        return make_criterion(fun)(
+            @property
+            def name(self):
+                return f"Composite StoppingCriterion: {self.name} AND {other.name}"
+
+            def completion(self) -> float:
+                return min(self.completion(), other.completion())
+
+        return CompositeCriterion(
             modify_result=self.modify_result or other.modify_result
         )
 
     def __or__(self, other: "StoppingCriterion") -> "StoppingCriterion":
-        def fun(result: ValuationResult):
-            return self(result) | other(result)
+        class CompositeCriterion(StoppingCriterion):
+            def check(self, result: ValuationResult) -> Status:
+                return self(result) | other(result)
 
-        fun.__name__ = f"Composite StoppingCriterion: {self.name} OR {other.name}"
-        return make_criterion(fun)(
+            @property
+            def name(self):
+                return f"Composite StoppingCriterion: {self.name} OR {other.name}"
+
+            def completion(self) -> float:
+                return max(self.completion(), other.completion())
+
+        return CompositeCriterion(
             modify_result=self.modify_result or other.modify_result
         )
 
     def __invert__(self) -> "StoppingCriterion":
-        def fun(result: ValuationResult):
-            return ~self(result)
+        class CompositeCriterion(StoppingCriterion):
+            def check(self, result: ValuationResult) -> Status:
+                return ~self(result)
 
-        fun.__name__ = f"Composite StoppingCriterion: NOT {self.name}"
-        return make_criterion(fun)(modify_result=self.modify_result)
+            @property
+            def name(self):
+                return f"Composite StoppingCriterion: NOT {self.name}"
+
+            def completion(self) -> float:
+                return 1 - self.completion()
+
+        return CompositeCriterion(modify_result=self.modify_result)
 
 
 def make_criterion(fun: StoppingCriterionCallable) -> Type[StoppingCriterion]:
-    """Create a new :class:`StoppingCriterion` from a function."""
+    """Create a new :class:`StoppingCriterion` from a function.
+    Use this to enable simpler functions to be composed with bitwise operators
+
+    :param fun: The callable to wrap.
+    :return: A new subclass of :class:`StoppingCriterion`.
+    """
 
     class WrappedCriterion(StoppingCriterion):
         def __init__(self, modify_result: bool = True):
@@ -103,35 +137,47 @@ def make_criterion(fun: StoppingCriterionCallable) -> Type[StoppingCriterion]:
         def name(self):
             return fun.__name__
 
+        def completion(self) -> float:
+            return 0.0  # FIXME: not much we can do about this...
+
     return WrappedCriterion
 
 
-class MedianRatio(StoppingCriterion):
-    """Compute a ratio of median errors to values to determine convergence.
+class StandardError(StoppingCriterion):
+    """Compute a ratio of standard errors to values to determine convergence.
 
-    :param threshold: Converged if the ratio of median standard error to median
-        of value has dropped below this value.
+    :param threshold: A value is considered to have converged if the ratio of
+        standard error to value has dropped below this value.
     """
+
+    converged: NDArray[np.bool_]
+    """A boolean array indicating whether the corresponding element has converged."""
 
     def __init__(self, threshold: float, modify_result: bool = True):
         super().__init__(modify_result=modify_result)
         self.threshold = threshold
+        self.converged = None  # type: ignore
 
     def check(self, result: ValuationResult) -> Status:
-        ratio = np.median(result.stderr) / np.median(result.values)
-        if ratio < self.threshold:
+        ratios = result.stderr / result.values
+        self.converged = np.where(ratios < self.threshold)
+        if np.all(self.converged):
             return Status.Converged
         return Status.Pending
+
+    def completion(self) -> float:
+        return np.mean(self.converged or [0]).item()
 
 
 class MaxUpdates(StoppingCriterion):
     """Terminate if any number of value updates exceeds or equals the given
     threshold.
 
-    This checks the ``counts`` field of a :class:`~pydvl.value.result.ValuationResult`, i.e. the number of times that
+    This checks the ``counts`` field of a
+    :class:`~pydvl.value.result.ValuationResult`, i.e. the number of times that
     each index has been updated. For powerset samplers, the maximum of this
-    number coincides with the maximum number of subsets sampled. For
-    permutation samplers, it coincides with the number of permutations sampled.
+    number coincides with the maximum number of subsets sampled. For permutation
+    samplers, it coincides with the number of permutations sampled.
 
     :param n_updates: Threshold: if ``None``, no check is performed,
         effectively creating a (never) stopping criterion that always returns
@@ -139,18 +185,21 @@ class MaxUpdates(StoppingCriterion):
     """
 
     def __init__(self, n_updates: Optional[int], modify_result: bool = True):
-        self.n_updates = n_updates
         super().__init__(modify_result=modify_result)
+        self.n_updates = n_updates
+        self.last_max = 0
 
     def check(self, result: ValuationResult) -> Status:
-        if self.n_updates is not None:
-            try:
-                if np.max(result.counts) >= self.n_updates:
-                    return Status.Converged
-            except AttributeError:
-                raise ValueError("ValuationResult didn't contain a `counts` attribute")
-
+        if self.n_updates:
+            self.last_max = np.max(result.counts)
+            if self.last_max >= self.n_updates:
+                return Status.Converged
         return Status.Pending
+
+    def completion(self) -> float:
+        if self.n_updates is None:
+            return 0.0
+        return np.max(self.last_max) / self.n_updates
 
 
 class MinUpdates(StoppingCriterion):
@@ -168,18 +217,21 @@ class MinUpdates(StoppingCriterion):
     """
 
     def __init__(self, n_updates: Optional[int], modify_result: bool = True):
-        self.n_updates = n_updates
         super().__init__(modify_result=modify_result)
+        self.n_updates = n_updates
+        self.last_min = 0
 
     def check(self, result: ValuationResult) -> Status:
         if self.n_updates is not None:
-            try:
-                if np.min(result.counts) >= self.n_updates:
-                    return Status.Converged
-            except AttributeError:
-                raise ValueError("ValuationResult didn't contain a `counts` attribute")
-
+            self.last_min = np.min(result.counts)
+            if self.last_min >= self.n_updates:
+                return Status.Converged
         return Status.Pending
+
+    def completion(self) -> float:
+        if self.n_updates is None:
+            return 0.0
+        return np.min(self.last_min) / self.n_updates
 
 
 class MaxTime(StoppingCriterion):
@@ -196,12 +248,19 @@ class MaxTime(StoppingCriterion):
     def __init__(self, seconds: Optional[float], modify_result: bool = True):
         super().__init__(modify_result=modify_result)
         self.max_seconds = seconds
+        if self.max_seconds <= 0:
+            raise ValueError("Number of seconds for MaxTime must be positive")
         self.start = time()
 
     def check(self, result: ValuationResult) -> Status:
         if self.max_seconds is not None and time() > self.start + self.max_seconds:
             return Status.Converged
         return Status.Pending
+
+    def completion(self) -> float:
+        if self.max_seconds is None:
+            return 0.0
+        return (time() - self.start) / self.max_seconds
 
 
 class HistoryDeviation(StoppingCriterion):
@@ -236,7 +295,7 @@ class HistoryDeviation(StoppingCriterion):
     """
 
     memory: NDArray[np.float_]
-    checked: NDArray[np.bool_]
+    converged: NDArray[np.bool_]
 
     def __init__(
         self,
@@ -253,14 +312,14 @@ class HistoryDeviation(StoppingCriterion):
 
         self.n_steps = n_steps
         self.rtol = rtol
-        self.pin_converged = pin_converged
+        self.update_op = np.logical_or if pin_converged else np.logical_and
         self.memory = None  # type: ignore
-        self.checked = None  # type: ignore
+        self.converged = None  # type: ignore
 
     def check(self, r: ValuationResult) -> Status:
         if self.memory is None:
             self.memory = np.full((len(r.values), self.n_steps + 1), np.inf)
-            self.checked = np.full(len(r), False)
+            self.converged = np.full(len(r), False)
             return Status.Pending
 
         # shift left: last column is the last set of values
@@ -278,19 +337,10 @@ class HistoryDeviation(StoppingCriterion):
             # quots holds the quotients when the denominator is non-zero, and
             # the absolute difference, which is just the memory, otherwise.
             if np.mean(quots) < self.rtol:
-                if not self.pin_converged:
-                    self.checked = np.full(len(r), False)
-                self.checked[ii] = True
-                if np.all(self.checked):
+                self.converged = self.update_op(self.converged, ii)
+                if np.all(self.converged):
                     return Status.Converged
         return Status.Pending
 
-    # def tmp(self):
-    #     # shift left: last column is the last set of values
-    #     memory = np.concatenate([memory[:, 1:], values.reshape(-1, 1)], axis=1)
-    #     if np.all(counts > n_steps):
-    #         diff = memory @ coefficients
-    #         passing_ratio = np.count_nonzero(diff < atol) / len(diff)
-    #         if passing_ratio >= values_ratio:
-    #             return ValuationStatus.Converged
-    #     return ValuationStatus.Pending
+    def completion(self) -> float:
+        return np.mean(self.converged or [0]).item()

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -28,6 +28,7 @@ def dummy_values(values, names):
 )
 def test_sorting(values, names, ranks_asc, dummy_values):
 
+    dummy_values.sort(key="value")
     assert np.alltrue([it.value for it in dummy_values] == sorted(values))
     assert np.alltrue(dummy_values.indices == ranks_asc)
     assert np.alltrue(
@@ -37,6 +38,10 @@ def test_sorting(values, names, ranks_asc, dummy_values):
     dummy_values.sort(reverse=True)
     assert np.alltrue([it.value for it in dummy_values] == sorted(values, reverse=True))
     assert np.alltrue(dummy_values.indices == list(reversed(ranks_asc)))
+
+    dummy_values.sort(key="index")
+    assert np.alltrue(dummy_values.indices == list(range(len(values))))
+    assert np.alltrue([it.value for it in dummy_values] == values)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -37,9 +37,6 @@ def test_sorting(values, names, ranks_asc, dummy_values):
     dummy_values.sort(reverse=True)
     assert np.alltrue([it.value for it in dummy_values] == sorted(values, reverse=True))
     assert np.alltrue(dummy_values.indices == list(reversed(ranks_asc)))
-    assert np.alltrue(
-        dummy_values.values[dummy_values.indices] == sorted(values, reverse=True)
-    )
 
 
 @pytest.mark.parametrize(
@@ -89,6 +86,9 @@ def test_todataframe(ranks_asc, dummy_values):
     assert "val" in df.columns
     assert "val_stderr" in df.columns
     assert np.alltrue(df.index.values == ranks_asc)
+
+    df = dummy_values.to_dataframe(use_names=True)
+    assert np.alltrue(df.index.values == [it.name for it in dummy_values])
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_dataset.py
+++ b/tests/utils/test_dataset.py
@@ -35,11 +35,9 @@ def test_creating_dataset_from_x_y_arrays(train_size):
 
 def test_creating_grouped_dataset_from_sklearn(train_size):
     data = load_wine()
-    data_groups = (
-        np.random.randint(low=0, high=3, size=int(train_size * len(data.data)))
-        .flat()
-        .tolist()
-    )
+    data_groups = np.random.randint(
+        low=0, high=3, size=int(train_size * len(data.data))
+    ).flatten()
     n_groups = len(np.unique(data_groups))
     dataset = GroupedDataset.from_sklearn(
         data, data_groups=data_groups, train_size=train_size
@@ -53,11 +51,9 @@ def test_creating_grouped_dataset_subsclassfrom_sklearn(train_size):
     class TestGroupedDataset(GroupedDataset):
         ...
 
-    data_groups = (
-        np.random.randint(low=0, high=3, size=int(train_size * len(data.data)))
-        .flat()
-        .tolist()
-    )
+    data_groups = np.random.randint(
+        low=0, high=3, size=int(train_size * len(data.data))
+    ).flatten()
     n_groups = len(np.unique(data_groups))
     dataset = TestGroupedDataset.from_sklearn(
         data, data_groups=data_groups, train_size=train_size
@@ -68,9 +64,9 @@ def test_creating_grouped_dataset_subsclassfrom_sklearn(train_size):
 
 def test_creating_grouped_dataset_from_x_y_arrays(train_size):
     X, y = make_classification()
-    data_groups = (
-        np.random.randint(low=0, high=3, size=int(train_size * len(X))).flat().tolist()
-    )
+    data_groups = np.random.randint(
+        low=0, high=3, size=int(train_size * len(X))
+    ).flatten()
     n_groups = len(np.unique(data_groups))
     dataset = GroupedDataset.from_arrays(
         X, y, data_groups=data_groups, train_size=train_size

--- a/tests/utils/test_numeric.py
+++ b/tests/utils/test_numeric.py
@@ -126,7 +126,7 @@ def test_running_moments():
     data = np.random.randn(n_samples, n_values)
     for i in range(n_values):
         new_values = data[:, i]
-        new_means, new_variances = running_moments(means, variances, new_values, counts)
+        new_means, new_variances = running_moments(means, variances, counts, new_values)
         means, variances = new_means, new_variances
         counts += 1
 

--- a/tests/utils/test_numeric.py
+++ b/tests/utils/test_numeric.py
@@ -50,7 +50,7 @@ def test_random_powerset(n, max_subsets):
     s = np.arange(n)
     item_counts = np.zeros_like(s, dtype=np.float_)
     size_counts = np.zeros(n + 1)
-    for subset in random_powerset(s, max_subsets=max_subsets):
+    for subset in random_powerset(s, n_samples=max_subsets):
         size_counts[len(subset)] += 1
         for item in subset:
             item_counts[item] += 1

--- a/tests/value/conftest.py
+++ b/tests/value/conftest.py
@@ -86,7 +86,7 @@ def analytic_shapley(dummy_utility):
     result = ValuationResult(
         algorithm="exact",
         values=values,
-        stderr=np.zeros_like(values),
+        variances=np.zeros_like(values),
         data_names=dummy_utility.data.indices,
         status=Status.Converged,
     )

--- a/tests/value/least_core/conftest.py
+++ b/tests/value/least_core/conftest.py
@@ -23,7 +23,7 @@ def test_utility(request) -> Tuple[Utility, ValuationResult]:
         algorithm="exact",
         values=exact_values,
         subsidy=subsidy,
-        stderr=np.zeros_like(exact_values),
+        variances=np.zeros_like(exact_values),
         data_names=np.arange(len(exact_values)),
         status=Status.Converged,
     )

--- a/tests/value/least_core/conftest.py
+++ b/tests/value/least_core/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from pydvl.utils import Utility
 from pydvl.utils.status import Status
 from pydvl.utils.utility import GlovesGameUtility, MinerGameUtility
-from pydvl.value.results import ValuationResult
+from pydvl.value.result import ValuationResult
 
 
 @pytest.fixture(scope="module")

--- a/tests/value/loo/conftest.py
+++ b/tests/value/loo/conftest.py
@@ -15,7 +15,7 @@ def analytic_loo(dummy_utility):
     result = ValuationResult(
         algorithm="exact",
         values=values,
-        stderr=np.zeros_like(values),
+        variances=np.zeros_like(values),
         data_names=dummy_utility.data.indices,
         status=Status.Converged,
     )

--- a/tests/value/shapley/test_montecarlo.py
+++ b/tests/value/shapley/test_montecarlo.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union, cast
+from typing import Union
 
 import numpy as np
 import pytest
@@ -27,14 +27,14 @@ log = logging.getLogger(__name__)
 @pytest.mark.parametrize(
     "num_samples, fun, rtol, kwargs",
     [
-        (12, ShapleyMode.PermutationMontecarlo, 0.1, {"stop": MaxUpdates(10)}),
+        (12, ShapleyMode.PermutationMontecarlo, 0.1, {"done": MaxUpdates(10)}),
         # FIXME! it should be enough with 2**(len(data)-1) samples
-        (8, ShapleyMode.CombinatorialMontecarlo, 0.2, {"stop": MaxUpdates(2**10)}),
+        (8, ShapleyMode.CombinatorialMontecarlo, 0.2, {"done": MaxUpdates(2**10)}),
         (
             12,
             ShapleyMode.TruncatedMontecarlo,
             0.1,
-            {"stop": MaxUpdates(10), "coordinator_update_period": 1},
+            {"done": MaxUpdates(10), "coordinator_update_period": 1},
         ),
         (12, ShapleyMode.Owen, 0.1, {"n_iterations": 4, "max_q": 200}),
         (12, ShapleyMode.OwenAntithetic, 0.1, {"n_iterations": 4, "max_q": 200}),
@@ -83,12 +83,12 @@ def test_hoeffding_bound_montecarlo(
     "fun, kwargs",
     [
         # FIXME: Hoeffding says 400 should be enough
-        (ShapleyMode.PermutationMontecarlo, dict(stop=MaxUpdates(600))),
+        (ShapleyMode.PermutationMontecarlo, dict(done=MaxUpdates(600))),
         (
             ShapleyMode.TruncatedMontecarlo,
-            dict(coordinator_update_period=1, stop=MaxUpdates(500)),
+            dict(coordinator_update_period=1, done=MaxUpdates(500)),
         ),
-        (ShapleyMode.CombinatorialMontecarlo, dict(stop=MaxUpdates(2**11))),
+        (ShapleyMode.CombinatorialMontecarlo, dict(done=MaxUpdates(2**11))),
         (ShapleyMode.Owen, dict(n_iterations=4, max_q=300)),
         # FIXME: antithetic breaks for non-deterministic u
         # (ShapleyMode.OwenAntithetic, dict(n_iterations=4, max_q=300)),
@@ -142,14 +142,13 @@ def test_linear_montecarlo_shapley(
 @pytest.mark.parametrize(
     "fun, kwargs",
     [
-        # (ShapleyMode.PermutationMontecarlo, {"stop": MaxUpdates(500)}),
+        # (ShapleyMode.PermutationMontecarlo, {"done": MaxUpdates(500)}),
         (
             ShapleyMode.TruncatedMontecarlo,
             dict(
                 coordinator_update_period=0.2,
                 worker_update_period=0.1,
-                stop=HistoryDeviation(n_samples=6, n_steps=10, rtol=0.1)
-                | MaxUpdates(500),
+                done=HistoryDeviation(n_steps=10, rtol=0.1) | MaxUpdates(500),
             ),
         ),
         # (ShapleyMode.Owen, dict(n_iterations=4, max_q=400)),
@@ -200,10 +199,10 @@ def test_linear_montecarlo_with_outlier(
 @pytest.mark.parametrize(
     "fun, kwargs",
     [
-        (ShapleyMode.PermutationMontecarlo, dict(stop=MaxUpdates(700))),
+        (ShapleyMode.PermutationMontecarlo, dict(done=MaxUpdates(700))),
         (
             ShapleyMode.TruncatedMontecarlo,
-            dict(stop=MaxUpdates(500), coordinator_update_period=0.5),
+            dict(done=MaxUpdates(500), coordinator_update_period=0.5),
         ),
         (ShapleyMode.Owen, dict(n_iterations=4, max_q=300)),
         # FIXME: antithetic breaks for non-deterministic u

--- a/tests/value/shapley/test_montecarlo.py
+++ b/tests/value/shapley/test_montecarlo.py
@@ -16,7 +16,7 @@ from pydvl.utils.numeric import (
 from pydvl.value import compute_shapley_values
 from pydvl.value.shapley import ShapleyMode
 from pydvl.value.shapley.naive import combinatorial_exact_shapley
-from pydvl.value.stopping import history_deviation, max_iterations
+from pydvl.value.stopping import HistoryDeviation, MaxIterations
 
 from .. import check_rank_correlation, check_total_value, check_values
 
@@ -27,19 +27,19 @@ log = logging.getLogger(__name__)
 @pytest.mark.parametrize(
     "num_samples, fun, rtol, kwargs",
     [
-        (12, ShapleyMode.PermutationMontecarlo, 0.1, {"stop": max_iterations(10)}),
+        (12, ShapleyMode.PermutationMontecarlo, 0.1, {"stop": MaxIterations(10)}),
         # FIXME! it should be enough with 2**(len(data)-1) samples
         (
             8,
             ShapleyMode.CombinatorialMontecarlo,
             0.2,
-            {"stop": max_iterations(2**10)},
+            {"stop": MaxIterations(2**10)},
         ),
         (
             12,
             ShapleyMode.TruncatedMontecarlo,
             0.1,
-            {"stop": max_iterations(10), "coordinator_update_period": 1},
+            {"stop": MaxIterations(10), "coordinator_update_period": 1},
         ),
         (12, ShapleyMode.Owen, 0.1, {"n_iterations": 4, "max_q": 200}),
         (12, ShapleyMode.OwenAntithetic, 0.1, {"n_iterations": 4, "max_q": 200}),
@@ -88,12 +88,12 @@ def test_hoeffding_bound_montecarlo(
     "fun, kwargs",
     [
         # FIXME: Hoeffding says 400 should be enough
-        (ShapleyMode.PermutationMontecarlo, dict(stop=max_iterations(600))),
+        (ShapleyMode.PermutationMontecarlo, dict(stop=MaxIterations(600))),
         (
             ShapleyMode.TruncatedMontecarlo,
-            dict(coordinator_update_period=1, stop=max_iterations(500)),
+            dict(coordinator_update_period=1, stop=MaxIterations(500)),
         ),
-        (ShapleyMode.CombinatorialMontecarlo, dict(stop=max_iterations(2**11))),
+        (ShapleyMode.CombinatorialMontecarlo, dict(stop=MaxIterations(2**11))),
         (ShapleyMode.Owen, dict(n_iterations=4, max_q=300)),
         # FIXME: antithetic breaks for non-deterministic u
         # (ShapleyMode.OwenAntithetic, dict(n_iterations=4, max_q=300)),
@@ -147,14 +147,14 @@ def test_linear_montecarlo_shapley(
 @pytest.mark.parametrize(
     "fun, kwargs",
     [
-        # (ShapleyMode.PermutationMontecarlo, {"stop": max_iterations(500)}),
+        # (ShapleyMode.PermutationMontecarlo, {"stop": MaxIterations(500)}),
         (
             ShapleyMode.TruncatedMontecarlo,
             dict(
                 coordinator_update_period=0.2,
                 worker_update_period=0.1,
-                stop=history_deviation(n_samples=6, n_steps=10, rtol=0.1)
-                | max_iterations(500),
+                stop=HistoryDeviation(n_samples=6, n_steps=10, rtol=0.1)
+                | MaxIterations(500),
             ),
         ),
         # (ShapleyMode.Owen, dict(n_iterations=4, max_q=400)),
@@ -209,10 +209,10 @@ def test_linear_montecarlo_with_outlier(
 @pytest.mark.parametrize(
     "fun, kwargs",
     [
-        (ShapleyMode.PermutationMontecarlo, dict(stop=max_iterations(700))),
+        (ShapleyMode.PermutationMontecarlo, dict(stop=MaxIterations(700))),
         (
             ShapleyMode.TruncatedMontecarlo,
-            dict(stop=max_iterations(500), coordinator_update_period=0.5),
+            dict(stop=MaxIterations(500), coordinator_update_period=0.5),
         ),
         (ShapleyMode.Owen, dict(n_iterations=4, max_q=300)),
         # FIXME: antithetic breaks for non-deterministic u

--- a/tests/value/shapley/test_montecarlo.py
+++ b/tests/value/shapley/test_montecarlo.py
@@ -185,6 +185,7 @@ def test_linear_montecarlo_with_outlier(
     values = compute_shapley_values(
         linear_utility, mode=fun, progress=False, n_jobs=1, **kwargs
     )
+    values.sort()
     from pydvl.utils import Status
 
     assert values.status == Status.Converged

--- a/tests/value/shapley/test_naive.py
+++ b/tests/value/shapley/test_naive.py
@@ -116,10 +116,11 @@ def test_linear_with_outlier(
         scoring=scorer,
         cache_options=MemcachedConfig(client_config=memcache_client_config),
     )
-    shapley_values = permutation_exact_shapley(linear_utility, progress=False)
-    check_total_value(linear_utility, shapley_values, atol=total_atol)
+    values = permutation_exact_shapley(linear_utility, progress=False)
+    values.sort()
+    check_total_value(linear_utility, values, atol=total_atol)
 
-    assert shapley_values.indices[0] == outlier_idx
+    assert values.indices[0] == outlier_idx
 
 
 @pytest.mark.parametrize(

--- a/tests/value/test_stopping.py
+++ b/tests/value/test_stopping.py
@@ -127,7 +127,7 @@ def test_max_time():
     assert done(v) == Status.Converged
 
 
-@pytest.mark.parametrize("n_steps", [1, 5, 53, 100])
+@pytest.mark.parametrize("n_steps", [1, 42, 100])
 @pytest.mark.parametrize("rtol", [0.01, 0.05])
 def test_history_deviation(n_steps, rtol):
     """Values are equal and set to 1/t. The criterion will be fulfilled after

--- a/tests/value/test_stopping.py
+++ b/tests/value/test_stopping.py
@@ -1,17 +1,117 @@
+import numpy as np
+import pytest
+
+from pydvl.utils import Status
+from pydvl.value import ValuationResult
+from pydvl.value.stopping import (
+    MaxUpdates,
+    MinUpdates,
+    StoppingCriterion,
+    make_criterion,
+)
+
+
 def test_stopping_criterion():
-    pass
+    stop = StoppingCriterion()
+    assert stop.name == "StoppingCriterion"
+    assert stop.modify_result is True
+    with pytest.raises(NotImplementedError):
+        stop(ValuationResult.empty())
 
 
 def test_stopping_criterion_composition():
-    pass
+    c = Status.Converged
+    p = Status.Pending
+    f = Status.Failed
+
+    class C(StoppingCriterion):
+        def check(self, result: ValuationResult) -> Status:
+            return c
+
+    class P(StoppingCriterion):
+        def check(self, result: ValuationResult) -> Status:
+            return p
+
+    class F(StoppingCriterion):
+        def check(self, result: ValuationResult) -> Status:
+            return f
+
+    v = ValuationResult.empty()
+
+    assert (~C())(v) == f
+    assert (~P())(v) == c
+    assert (~F())(v) == c
+
+    assert (C() & C())(v) == c
+    assert (P() | P())(v) == p
+
+    assert (C() & P())(v) == (c & p)
+    assert (C() | P())(v) == (c | p)
+
+    assert (C() & C() & C())(v) == c
+    assert (P() | P() | P())(v) == p
+
+    assert (C() & P()).name == "Composite StoppingCriterion: C AND P"
+    assert (C() | P()).name == "Composite StoppingCriterion: C OR P"
+    assert (~C()).name == "Composite StoppingCriterion: NOT C"
+    assert (~P()).name == "Composite StoppingCriterion: NOT P"
 
 
 def test_make_criterion():
-    pass
+    def always_converged(result: ValuationResult) -> Status:
+        return Status.Converged
+
+    def always_pending(result: ValuationResult) -> Status:
+        return Status.Pending
+
+    def always_failed(result: ValuationResult) -> Status:
+        return Status.Failed
+
+    v = ValuationResult.empty()
+
+    C = make_criterion(always_converged)
+    P = make_criterion(always_pending)
+    F = make_criterion(always_failed)
+
+    assert C()(v) == Status.Converged
+    assert P()(v) == Status.Pending
+    assert F()(v) == Status.Failed
+
+    assert C().name == "always_converged"
+    assert P().name == "always_pending"
+    assert F().name == "always_failed"
+
+    assert (~C())(v) == Status.Failed
+    assert (~P())(v) == Status.Converged
+    assert (~F())(v) == Status.Converged
+
+    assert (C() & C())(v) == Status.Converged
+    assert (P() | P())(v) == Status.Pending
+    assert (F() & F())(v) == Status.Failed
+    assert (C() | F())(v) == Status.Converged
 
 
-def test_max_iterations():
-    pass
+def test_minmax_updates():
+    maxstop = MaxUpdates(10)
+    assert maxstop.name == "MaxUpdates"
+    v = ValuationResult.from_random(5)
+    v.counts = np.zeros(5)
+    assert maxstop(v) == Status.Pending
+    v.counts += np.ones(5) * 9
+    assert maxstop(v) == Status.Pending
+    v.counts[0] += 1
+    assert maxstop(v) == Status.Converged
+
+    minstop = MinUpdates(10)
+    assert minstop.name == "MinUpdates"
+    v.counts = np.zeros(5)
+    assert minstop(v) == Status.Pending
+    v.counts += np.ones(5) * 9
+    assert minstop(v) == Status.Pending
+    v.counts[0] += 1
+    assert minstop(v) == Status.Pending
+    v.counts += np.ones(5)
+    assert minstop(v) == Status.Converged
 
 
 def test_max_time():

--- a/tests/value/test_stopping.py
+++ b/tests/value/test_stopping.py
@@ -1,0 +1,22 @@
+def test_stopping_criterion():
+    pass
+
+
+def test_stopping_criterion_composition():
+    pass
+
+
+def test_make_criterion():
+    pass
+
+
+def test_max_iterations():
+    pass
+
+
+def test_max_time():
+    pass
+
+
+def test_history_deviation():
+    pass

--- a/tests/value/test_stopping.py
+++ b/tests/value/test_stopping.py
@@ -45,7 +45,7 @@ def test_stopping_criterion_composition():
         def _check(self, result: ValuationResult) -> Status:
             return f
 
-    v = ValuationResult()
+    v = ValuationResult.empty()
 
     assert (~C())(v) == f
     assert (~P())(v) == c
@@ -76,7 +76,7 @@ def test_make_criterion():
     def always_failed(result: ValuationResult) -> Status:
         return Status.Failed
 
-    v = ValuationResult()
+    v = ValuationResult.empty()
 
     C = make_criterion(always_converged)
     P = make_criterion(always_pending)

--- a/tests/value/test_stopping.py
+++ b/tests/value/test_stopping.py
@@ -17,14 +17,18 @@ from pydvl.value.stopping import (
 
 
 def test_stopping_criterion():
+    with pytest.raises(TypeError):
+        StoppingCriterion()
+
+    StoppingCriterion.__abstractmethods__ = set()
     done = StoppingCriterion()
     assert done.name == "StoppingCriterion"
     assert done.modify_result is True
-    with pytest.raises(NotImplementedError):
-        done(ValuationResult.empty())
 
 
 def test_stopping_criterion_composition():
+    StoppingCriterion.__abstractmethods__ = set()
+
     c = Status.Converged
     p = Status.Pending
     f = Status.Failed
@@ -100,22 +104,22 @@ def test_minmax_updates():
     maxstop = MaxUpdates(10)
     assert maxstop.name == "MaxUpdates"
     v = ValuationResult.from_random(5)
-    v.counts = np.zeros(5)
+    v._counts = np.zeros(5)
     assert maxstop(v) == Status.Pending
-    v.counts += np.ones(5) * 9
+    v._counts += np.ones(5) * 9
     assert maxstop(v) == Status.Pending
-    v.counts[0] += 1
+    v._counts[0] += 1
     assert maxstop(v) == Status.Converged
 
     minstop = MinUpdates(10)
     assert minstop.name == "MinUpdates"
-    v.counts = np.zeros(5)
+    v._counts = np.zeros(5)
     assert minstop(v) == Status.Pending
-    v.counts += np.ones(5) * 9
+    v._counts += np.ones(5) * 9
     assert minstop(v) == Status.Pending
-    v.counts[0] += 1
+    v._counts[0] += 1
     assert minstop(v) == Status.Pending
-    v.counts += np.ones(5)
+    v._counts += np.ones(5)
     assert minstop(v) == Status.Converged
 
 

--- a/tests/value/test_stopping.py
+++ b/tests/value/test_stopping.py
@@ -34,15 +34,15 @@ def test_stopping_criterion_composition():
     f = Status.Failed
 
     class C(StoppingCriterion):
-        def check(self, result: ValuationResult) -> Status:
+        def _check(self, result: ValuationResult) -> Status:
             return c
 
     class P(StoppingCriterion):
-        def check(self, result: ValuationResult) -> Status:
+        def _check(self, result: ValuationResult) -> Status:
             return p
 
     class F(StoppingCriterion):
-        def check(self, result: ValuationResult) -> Status:
+        def _check(self, result: ValuationResult) -> Status:
             return f
 
     v = ValuationResult()

--- a/tests/value/test_stopping.py
+++ b/tests/value/test_stopping.py
@@ -45,7 +45,7 @@ def test_stopping_criterion_composition():
         def check(self, result: ValuationResult) -> Status:
             return f
 
-    v = ValuationResult.empty()
+    v = ValuationResult()
 
     assert (~C())(v) == f
     assert (~P())(v) == c
@@ -76,7 +76,7 @@ def test_make_criterion():
     def always_failed(result: ValuationResult) -> Status:
         return Status.Failed
 
-    v = ValuationResult.empty()
+    v = ValuationResult()
 
     C = make_criterion(always_converged)
     P = make_criterion(always_pending)

--- a/tests/value/test_stopping.py
+++ b/tests/value/test_stopping.py
@@ -1,9 +1,12 @@
+from time import sleep
+
 import numpy as np
 import pytest
 
 from pydvl.utils import Status
 from pydvl.value import ValuationResult
 from pydvl.value.stopping import (
+    MaxTime,
     MaxUpdates,
     MinUpdates,
     StoppingCriterion,
@@ -115,7 +118,11 @@ def test_minmax_updates():
 
 
 def test_max_time():
-    pass
+    v = ValuationResult.from_random(5)
+    stop = MaxTime(0.3)
+    assert stop(v) == Status.Pending
+    sleep(0.3)
+    assert stop(v) == Status.Converged
 
 
 def test_history_deviation():


### PR DESCRIPTION
<!--
Thanks for making a contribution! 
Please make sure you have read the contributing guide: 
https://github.com/appliedAI-Initiative/pyDVL/blob/develop/CONTRIBUTING.md
-->

### Description

This PR closes #241 

### Changes

- Adds `StoppingCriterion` for use with (some) Monte Carlo methods
- Implements min and max updates, max time, standard error checks, and Ghorbani's criterion
- Adds `TruncationPolicy` for use with TMCS (to reproduce all choices in the paper, including those in the appendix)
- Improves implementation of `ValuationResult` to allow adding of results with different index sets
- Removes `MonteCarloResult` in favour of `ValuationResult` everywhere
- Simplifies some code and removes stale one.
- Closes #219 with a string key instead of a lambda for simplicity (should be enough since the container is not generic)
- Closes #220 by removing state, which would have been too complex after adding support for different sort keys
- Closes #212 by using running moments in `ValuationResult`

### Checklist

- [x] Wrote Unit tests (if necessary)
- [x] Updated Documentation (if necessary)
- [x] Updated Changelog
- [x] ~If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`~
