### PR TITLE
Some fixes for RayParallelBackend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Unreleased
 
-- Splitting of problem preparation and solution in Least Core computation.
+- Bugfix in `RayParallelBackend`: wrong semantics for `kwargs`.
+  [PR #268](https://github.com/appliedAI-Initiative/pyDVL/pull/268)
+- Splitting of problem preparation and solution in Least-Core computation.
   Umbrella function for LC methods.
   [PR #257](https://github.com/appliedAI-Initiative/pyDVL/pull/257) 
-- Operations on ValuationResults and Statuses and cleanup
+- Operations on `ValuationResult` and `Status` and some cleanup
   [PR #248](https://github.com/appliedAI-Initiative/pyDVL/pull/248)
 - **Bug fix and minor improvements**: Fixes bug in TMCS with remote Ray cluster,
   raises an error for dummy sequential parallel backend with TMCS, clones model
@@ -25,8 +27,8 @@
 - **Breaking change:** Introduces a class ValuationResult to gather and inspect
   results from all valuation algorithms
   [PR #214](https://github.com/appliedAI-Initiative/pyDVL/pull/214)
-- Fixes bug in Influence calculation with multi-dimensional input and adds
-  new example notebook
+- Fixes bug in Influence calculation with multidimensional input and adds new
+  example notebook
   [PR #195](https://github.com/appliedAI-Initiative/pyDVL/pull/195)
 - **Breaking change**: Passes the input to `MapReduceJob` at initialization,
   removes `chunkify_inputs` argument from `MapReduceJob`, removes `n_runs`

--- a/src/pydvl/utils/parallel/actor.py
+++ b/src/pydvl/utils/parallel/actor.py
@@ -39,7 +39,7 @@ class RayActorWrapper:
     def __init__(self, actor_class: Type, config: ParallelConfig, *args, **kwargs):
         parallel_backend = cast(RayParallelBackend, init_parallel_backend(config))
         remote_cls = parallel_backend.wrap(actor_class)
-        self.actor_handle = remote_cls.remote(*args, **kwargs)
+        self.actor_handle = remote_cls(*args, **kwargs)
 
         def remote_caller(method_name: str):
             # Wrapper for remote class' methods to mimic local calls

--- a/src/pydvl/utils/parallel/map_reduce.py
+++ b/src/pydvl/utils/parallel/map_reduce.py
@@ -219,10 +219,19 @@ class MapReduceJob(Generic[T, R]):
         return result  # type: ignore
 
     def _wrap_function(self, func: Callable, **kwargs) -> Callable:
-        remote_func = self.parallel_backend.wrap(
+        """Wraps a function with a timeout and remote arguments and puts it on
+        the remote backend.
+
+        :param func: Function to wrap
+        :param kwargs: Additional keyword arguments to pass to the backend
+            wrapper. These are *not* arguments for the wrapped function.
+        :return: Remote function that can be called with the same arguments as
+            the wrapped function. Depending on the backend, this may simply be
+            the function itself.
+        """
+        return self.parallel_backend.wrap(
             _wrap_func_with_remote_args(func, timeout=self.timeout), **kwargs
         )
-        return getattr(remote_func, "remote", remote_func)  # type: ignore
 
     def _backpressure(
         self, jobs: List[ObjectRef], n_dispatched: int, n_finished: int

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,7 +189,7 @@ def seed_numpy(seed=42):
     np.random.seed(seed)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def num_workers():
     return max(1, available_cpus() - 1)
 

--- a/tests/utils/conftest.py
+++ b/tests/utils/conftest.py
@@ -6,7 +6,7 @@ from pydvl.utils.config import ParallelConfig
 
 
 @pytest.fixture(scope="module", params=["sequential", "ray-local", "ray-external"])
-def parallel_config(request):
+def parallel_config(request, num_workers):
     if request.param == "sequential":
         yield ParallelConfig(backend=request.param)
     elif request.param == "ray-local":
@@ -17,7 +17,7 @@ def parallel_config(request):
         cluster = Cluster(
             initialize_head=True,
             head_node_args={
-                "num_cpus": 4,
+                "num_cpus": num_workers,
             },
         )
         yield ParallelConfig(backend="ray", address=cluster.address)

--- a/tests/utils/test_parallel.py
+++ b/tests/utils/test_parallel.py
@@ -9,7 +9,7 @@ from pydvl.utils.parallel.backend import available_cpus
 from pydvl.utils.parallel.map_reduce import _get_value
 
 
-def test_effective_n_jobs(parallel_config):
+def test_effective_n_jobs(parallel_config, num_workers):
     parallel_backend = init_parallel_backend(parallel_config)
     if parallel_config.backend == "sequential":
         assert parallel_backend.effective_n_jobs(1) == 1
@@ -21,7 +21,7 @@ def test_effective_n_jobs(parallel_config):
         if parallel_config.address is None:
             assert parallel_backend.effective_n_jobs(-1) == available_cpus()
         else:
-            assert parallel_backend.effective_n_jobs(-1) == 4
+            assert parallel_backend.effective_n_jobs(-1) == num_workers
 
 
 @pytest.fixture()


### PR DESCRIPTION
<!--
Thanks for making a contribution! 
Please make sure you have read the contributing guide: 
https://github.com/appliedAI-Initiative/pyDVL/blob/develop/CONTRIBUTING.md
-->

### Description

This PR closes #255 and fixes the semantics of `kwargs` for `ParallelBackend.wrap()` to mean that these are passed to the wrapping, not the wrapped function.

### Changes

- Correctly calls `ray.remote(**kwargs)(fun)`
- Changes the signature of `ParallelBackend.wrap` to only take a `Callable` and options for the wrapper
- Adds some (naive) tests

### Checklist

- [x] Wrote Unit tests (if necessary)
- [x] ~Updated Documentation (if necessary)~
- [x] Updated Changelog
- [x] ~If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`~
