### PR TITLE
Fix Monte Carlo Least Core error when n_iterations < len(dataset)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Bug fix**: Warn instead of raise an error when `n_iterations`
   is less than the size of the dataset in Monte Carlo Least Core
-  [PR #279](https://github.com/appliedAI-Initiative/pyDVL/pull/279)
+  [PR #281](https://github.com/appliedAI-Initiative/pyDVL/pull/281)
 
 ## 0.5.0 - 💥 Fixes, nicer interfaces and... more breaking changes 😒
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- **Bug fix**: Warn instead of raise an error when `n_iterations`
+- **Bug fix**: Warn instead of raising an error when `n_iterations`
   is less than the size of the dataset in Monte Carlo Least Core
   [PR #281](https://github.com/appliedAI-Initiative/pyDVL/pull/281)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- **Bug fix**: Warn instead of raise an error when `n_iterations`
+  is less than the size of the dataset in Monte Carlo Least Core
+  [PR #279](https://github.com/appliedAI-Initiative/pyDVL/pull/279)
+
 ## 0.5.0 - 💥 Fixes, nicer interfaces and... more breaking changes 😒
 
 - Fixed parallel and antithetic Owen sampling for Shapley values. Simplified

--- a/src/pydvl/value/least_core/montecarlo.py
+++ b/src/pydvl/value/least_core/montecarlo.py
@@ -125,8 +125,10 @@ def mclc_prepare_problem(
     n = len(u.data)
 
     if n_iterations < n:
-        raise ValueError(
-            "Number of iterations should be greater than the size of the dataset"
+        warnings.warn(
+            f"Number of iterations '{n_iterations}' is smaller the size of the dataset '{n}'. "
+            f"This is not optimal because in the worst case we need at least '{n}' constraints "
+            "to satisfy the individual rationality condition."
         )
 
     if n_iterations > 2**n:

--- a/src/pydvl/value/least_core/montecarlo.py
+++ b/src/pydvl/value/least_core/montecarlo.py
@@ -22,46 +22,6 @@ __all__ = [
 ]
 
 
-def _montecarlo_least_core(
-    u: Utility, n_iterations: int, *, progress: bool = False, job_id: int = 1
-) -> LeastCoreProblem:
-    """Computes utility values and the Least Core upper bound matrix for a given number of iterations.
-
-    :param u: Utility object with model, data, and scoring function
-    :param n_iterations: total number of iterations to use
-    :param progress: If True, shows a tqdm progress bar
-    :param job_id: Integer id used to determine the position of the progress bar
-    :return:
-    """
-    n = len(u.data)
-
-    utility_values = np.zeros(n_iterations)
-
-    # Randomly sample subsets of full dataset
-    power_set = random_powerset(u.data.indices, n_samples=n_iterations)
-
-    A_lb = np.zeros((n_iterations, n))
-
-    for i, subset in enumerate(
-        maybe_progress(power_set, progress, total=n_iterations, position=job_id)
-    ):
-        indices = np.zeros(n, dtype=bool)
-        indices[list(subset)] = True
-        A_lb[i, indices] = 1
-        utility_values[i] = u(subset)
-
-    return LeastCoreProblem(utility_values, A_lb)
-
-
-def _reduce_func(results: Iterable[LeastCoreProblem]) -> LeastCoreProblem:
-    """Combines the results from different parallel runs of
-    :func:`_montecarlo_least_core`"""
-    utility_values_list, A_lb_list = zip(*results)
-    utility_values = np.concatenate(utility_values_list)
-    A_lb = np.concatenate(A_lb_list)
-    return LeastCoreProblem(utility_values, A_lb)
-
-
 def montecarlo_least_core(
     u: Utility,
     n_iterations: int,
@@ -151,3 +111,43 @@ def mclc_prepare_problem(
     )
 
     return map_reduce_job()
+
+
+def _montecarlo_least_core(
+    u: Utility, n_iterations: int, *, progress: bool = False, job_id: int = 1
+) -> LeastCoreProblem:
+    """Computes utility values and the Least Core upper bound matrix for a given number of iterations.
+
+    :param u: Utility object with model, data, and scoring function
+    :param n_iterations: total number of iterations to use
+    :param progress: If True, shows a tqdm progress bar
+    :param job_id: Integer id used to determine the position of the progress bar
+    :return:
+    """
+    n = len(u.data)
+
+    utility_values = np.zeros(n_iterations)
+
+    # Randomly sample subsets of full dataset
+    power_set = random_powerset(u.data.indices, n_samples=n_iterations)
+
+    A_lb = np.zeros((n_iterations, n))
+
+    for i, subset in enumerate(
+        maybe_progress(power_set, progress, total=n_iterations, position=job_id)
+    ):
+        indices = np.zeros(n, dtype=bool)
+        indices[list(subset)] = True
+        A_lb[i, indices] = 1
+        utility_values[i] = u(subset)
+
+    return LeastCoreProblem(utility_values, A_lb)
+
+
+def _reduce_func(results: Iterable[LeastCoreProblem]) -> LeastCoreProblem:
+    """Combines the results from different parallel runs of
+    :func:`_montecarlo_least_core`"""
+    utility_values_list, A_lb_list = zip(*results)
+    utility_values = np.concatenate(utility_values_list)
+    A_lb = np.concatenate(A_lb_list)
+    return LeastCoreProblem(utility_values, A_lb)

--- a/tests/value/least_core/test_montecarlo.py
+++ b/tests/value/least_core/test_montecarlo.py
@@ -35,17 +35,3 @@ def test_montecarlo_least_core(test_utility, rtol, n_iterations, n_jobs):
         u, n_iterations=n_iterations, progress=False, n_jobs=n_jobs
     )
     check_values(values, exact_values, rtol=rtol, extra_values_names=["subsidy"])
-
-
-@pytest.mark.parametrize(
-    "test_utility, n_iterations",
-    [
-        (("miner", {"n_miners": 8}), 3),
-    ],
-    indirect=["test_utility"],
-)
-def test_montecarlo_least_core_failure(test_utility, n_iterations):
-    u, exact_values = test_utility
-
-    with pytest.raises(ValueError):
-        montecarlo_least_core(u, n_iterations=n_iterations, progress=False)


### PR DESCRIPTION
### Description

This PR closes #251

### Changes

- Prints a warning instead of raising an error when `n_iterations` < len(dataset) in Monte Carlo Least Core.
- Moved `montecarlo_least_core` higher in the module for readability.
- Removed test that is no longer needed.

### Checklist

- [X] Wrote Unit tests (if necessary)
- [ ] Updated Documentation (if necessary)
- [X] Updated Changelog
- [ ] If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`
