### PR TITLE
Fix/stopping checks

### DIFF
--- a/src/pydvl/value/shapley/actor.py
+++ b/src/pydvl/value/shapley/actor.py
@@ -164,8 +164,12 @@ class ShapleyWorker(Worker):
                 if self.coordinator.is_done():
                     return
                 results = self._compute_marginals()
-                if np.any(np.isnan(results.values)):
-                    logger.warning("NaN values in current permutation, ignoring")
+                nans = np.isnan(results.values).sum()
+                if nans > 0:
+                    logger.warning(
+                        f"{nans} NaN values in current permutation, ignoring. "
+                        "Consider setting a default value for the Scorer"
+                    )
                     continue
                 acc += results
             self.coordinator.add_results(acc)


### PR DESCRIPTION
<!--
Thanks for making a contribution! 
Please make sure you have read the contributing guide: 
https://github.com/appliedAI-Initiative/pyDVL/blob/develop/CONTRIBUTING.md
-->

### Description

This PR closes provides more information for when a Scorer returns NaNs

### Changes

- Added a check for empty results in `StoppingCriterion`
- Added log messages to help the user with poorly configured `Scorer` (this makes a case for #272, including default values)

### Checklist

- [x] ~Wrote Unit tests (if necessary)~
- [x] ~Updated Documentation (if necessary)~
- [x] ~Updated Changelog~
- [x] ~If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`~
