### PR TITLE
Hide parallel backend in tmcs main function

### DIFF
--- a/src/pydvl/value/shapley/actor.py
+++ b/src/pydvl/value/shapley/actor.py
@@ -14,6 +14,7 @@ from typing import cast
 import numpy as np
 
 from pydvl.utils.config import ParallelConfig
+from pydvl.utils.parallel import init_parallel_backend
 from pydvl.utils.parallel.actor import Coordinator, RayActorWrapper, Worker
 from pydvl.utils.utility import Utility
 from pydvl.value.result import ValuationResult
@@ -42,14 +43,16 @@ def get_shapley_coordinator(
 
 
 def get_shapley_worker(
-    *args, config: ParallelConfig = ParallelConfig(), **kwargs
+    u: Utility, *args, config: ParallelConfig = ParallelConfig(), **kwargs
 ) -> "ShapleyWorker":
+    parallel_backend = init_parallel_backend(config)
+    u_id = parallel_backend.put(u)
     if config.backend == "ray":
         worker = cast(
-            ShapleyWorker, RayActorWrapper(ShapleyWorker, config, *args, **kwargs)
+            ShapleyWorker, RayActorWrapper(ShapleyWorker, config, u_id, *args, **kwargs)
         )
     elif config.backend == "sequential":
-        worker = ShapleyWorker(*args, **kwargs)
+        worker = ShapleyWorker(u_id, *args, **kwargs)
     else:
         raise NotImplementedError(f"Unexpected parallel type {config.backend}")
     return worker

--- a/src/pydvl/value/shapley/truncated.py
+++ b/src/pydvl/value/shapley/truncated.py
@@ -4,7 +4,7 @@ from time import sleep
 
 import numpy as np
 
-from pydvl.utils import ParallelConfig, Utility, init_parallel_backend, running_moments
+from pydvl.utils import ParallelConfig, Utility, running_moments
 from pydvl.value import ValuationResult
 from pydvl.value.stopping import StoppingCriterion
 
@@ -216,15 +216,11 @@ def truncated_montecarlo_shapley(
             "the Sequential parallel backend."
         )
 
-    parallel_backend = init_parallel_backend(config)
-    n_jobs = parallel_backend.effective_n_jobs(n_jobs)
-    u_id = parallel_backend.put(u)
-
     coordinator = get_shapley_coordinator(config=config, done=done)  # type: ignore
 
     workers = [
         get_shapley_worker(  # type: ignore
-            u=u_id,
+            u,
             coordinator=coordinator,
             truncation=truncation,
             worker_id=worker_id,


### PR DESCRIPTION
<!--
Thanks for making a contribution! 
Please make sure you have read the contributing guide: 
https://github.com/appliedAI-Initiative/pyDVL/blob/develop/CONTRIBUTING.md
-->

### Description

This PR closes hides the parallel_backend details inside `get_shapley_worker`, to which `truncated_montecarlo_shapley` now simply passes the utility, without first `put()`ting it to the backend.

### Changes

- `put()` the utility inside `get_shapley_worker`. This is just a cosmetic change which doesn't change user code, documentation or functionality in any way

### Checklist

- [ ] Wrote Unit tests (if necessary)
- [ ] Updated Documentation (if necessary)
- [ ] Updated Changelog
- [ ] If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`
