### PR TITLE
Add burn-in param to AbsoluteStandardError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Stopping criteria: fixed problem with `StandardError` and enable proper composition
   of index convergence statuses. Fixed a bug with `n_jobs` in
   `truncated_montecarlo_shapley`.
-  [PR #300](https://github.com/appliedAI-Initiative/pyDVL/pull/300)
+  [PR #300](https://github.com/appliedAI-Initiative/pyDVL/pull/300) and
+  [PR #305](https://github.com/appliedAI-Initiative/pyDVL/pull/305)
 - Shuffling code around to allow for simpler user imports, some cleanup and
   documentation fixes.
   [PR #284](https://github.com/appliedAI-Initiative/pyDVL/pull/284)

--- a/src/pydvl/value/stopping.py
+++ b/src/pydvl/value/stopping.py
@@ -195,7 +195,9 @@ class AbsoluteStandardError(StoppingCriterion):
     :param burn_in: The number of iterations to ignore before checking for
         convergence. This is required because computations typically start with
         zero variance, as a result of using
-        :meth:`~pydvl.value.result.ValuationResult.empty`.
+        :meth:`~pydvl.value.result.ValuationResult.empty`. The default is set to
+        an arbitrary minimum which is usually enough but may need to be
+        increased.
     """
 
     def __init__(

--- a/tests/value/test_stopping.py
+++ b/tests/value/test_stopping.py
@@ -162,7 +162,7 @@ def test_standard_error():
     eps = 0.1
     n = 5
 
-    done = AbsoluteStandardError(threshold=eps)
+    done = AbsoluteStandardError(threshold=eps, fraction=1.0, burn_in=0)
 
     # Trivial case: no variance.
     v = ValuationResult(values=np.ones(n), variances=np.zeros(n))


### PR DESCRIPTION
<!--
Thanks for making a contribution! 
Please make sure you have read the contributing guide: 
https://github.com/appliedAI-Initiative/pyDVL/blob/develop/CONTRIBUTING.md
-->

### Description

This PR fixes a problem with `AbsoluteStandardError` whereby empty results are marked as having converged because an empty result has zero variance.

### Changes

- Add a burn-in parameter to allow for the variances to have been updated to a realistic value. 

### Checklist

- [x] Wrote Unit tests (if necessary)
- [x] Updated Documentation (if necessary)
- [x] Updated Changelog
- [x] If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`
