### PR TITLE
Allow passing additional kwargs to Dataset class' classmethods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Adds kwargs parameter to `from_array` and `from_sklearn`
+  Dataset and GroupedDataset class methods
+  [PR #316](https://github.com/appliedAI-Initiative/pyDVL/pull/316)
 - PEP-561 conformance: added `py.typed`
   [PR #307](https://github.com/appliedAI-Initiative/pyDVL/pull/307)
 - Removed default non-negativity constraint on least core subsidy

--- a/src/pydvl/utils/dataset.py
+++ b/src/pydvl/utils/dataset.py
@@ -344,6 +344,7 @@ class GroupedDataset(Dataset):
         target_names: Optional[Sequence[str]] = None,
         group_names: Optional[Sequence[str]] = None,
         description: Optional[str] = None,
+        **kwargs,
     ):
         """Class for grouping datasets.
 
@@ -371,7 +372,14 @@ class GroupedDataset(Dataset):
            Added `group_names` argument
         """
         super().__init__(
-            x_train, y_train, x_test, y_test, feature_names, target_names, description
+            x_train=x_train,
+            y_train=y_train,
+            x_test=x_test,
+            y_test=y_test,
+            feature_names=feature_names,
+            target_names=target_names,
+            description=description,
+            **kwargs,
         )
 
         if len(data_groups) != len(x_train):

--- a/src/pydvl/utils/dataset.py
+++ b/src/pydvl/utils/dataset.py
@@ -253,6 +253,7 @@ class Dataset:
         train_size: float = 0.8,
         random_state: Optional[int] = None,
         stratify_by_target: bool = False,
+        **kwargs,
     ) -> "Dataset":
         """Constructs a :class:`Dataset` object from an :class:`sklearn.utils.Bunch` bunch as returned by the
         `load_*` functions in `sklearn toy datasets
@@ -267,6 +268,8 @@ class Dataset:
             `sklearn's user guide
             <https://scikit-learn.org/stable/modules/cross_validation.html
             #stratification>`.
+        :param kwargs: Additional keyword arguments that will be passed
+            to the class constructor.
 
         :return: Dataset with the selected sklearn data
         """
@@ -285,6 +288,7 @@ class Dataset:
             feature_names=data.get("feature_names"),
             target_names=data.get("target_names"),
             description=data.get("DESCR"),
+            **kwargs,
         )
 
     @classmethod
@@ -295,6 +299,7 @@ class Dataset:
         train_size: float = 0.8,
         random_state: Optional[int] = None,
         stratify_by_target: bool = False,
+        **kwargs,
     ) -> "Dataset":
         """.. versionadded:: 0.4.0
 
@@ -312,6 +317,8 @@ class Dataset:
             `sklearn's user guide
             <https://scikit-learn.org/stable/modules/cross_validation.html
             #stratification>`.
+        :param kwargs: Additional keyword arguments that will be passed
+            to the class constructor.
 
         :return: Dataset with the passed X and y arrays split across training and test sets.
         """
@@ -322,7 +329,7 @@ class Dataset:
             random_state=random_state,
             stratify=y if stratify_by_target else None,
         )
-        return cls(x_train, y_train, x_test, y_test)
+        return cls(x_train, y_train, x_test, y_test, **kwargs)
 
 
 class GroupedDataset(Dataset):
@@ -423,6 +430,7 @@ class GroupedDataset(Dataset):
         random_state: Optional[int] = None,
         stratify_by_target: bool = False,
         data_groups: Optional[Sequence] = None,
+        **kwargs,
     ) -> "GroupedDataset":
         """Constructs a :class:`GroupedDataset` object from an sklearn bunch as returned by the
         `load_*` functions in `sklearn toy datasets
@@ -440,13 +448,15 @@ class GroupedDataset(Dataset):
             #stratification>`.
         :param data_groups: for each element in the training set, it associates
             a group index or name.
+        :param kwargs: Additional keyword arguments that will be passed
+            to the :class:`~pydvl.utils.dataset.Dataset` constructor.
 
         :return: Dataset with the selected sklearn data
         """
         if data_groups is None:
             raise ValueError("data_groups argument is missing")
         dataset = Dataset.from_sklearn(
-            data, train_size, random_state, stratify_by_target
+            data, train_size, random_state, stratify_by_target, **kwargs
         )
         return cls.from_dataset(dataset, data_groups)
 
@@ -459,6 +469,7 @@ class GroupedDataset(Dataset):
         random_state: Optional[int] = None,
         stratify_by_target: bool = False,
         data_groups: Optional[Sequence] = None,
+        **kwargs,
     ) -> "Dataset":
         """Constructs a :class:`GroupedDataset` object from X and y numpy arrays
         as returned by the `make_*` functions in `sklearn generated datasets
@@ -476,6 +487,8 @@ class GroupedDataset(Dataset):
             #stratification>`.
         :param data_groups: for each element in the training set, and associated
             group index or name.
+        :param kwargs: Additional keyword arguments that will be passed
+            to the :class:`~pydvl.utils.dataset.Dataset` constructor.
 
         :return: Dataset with the passed X and y arrays split across training
             and test sets.
@@ -485,7 +498,12 @@ class GroupedDataset(Dataset):
         if data_groups is None:
             raise ValueError("data_groups argument is missing")
         dataset = Dataset.from_arrays(
-            X, y, train_size, random_state, stratify_by_target
+            X,
+            y,
+            train_size,
+            random_state,
+            stratify_by_target,
+            **kwargs,
         )
         return cls.from_dataset(dataset, data_groups)
 

--- a/tests/utils/test_dataset.py
+++ b/tests/utils/test_dataset.py
@@ -27,10 +27,13 @@ def test_creating_dataset_subsclassfrom_sklearn(train_size):
     assert len(dataset) == int(train_size * len(data.data))
 
 
-def test_creating_dataset_from_x_y_arrays(train_size):
+@pytest.mark.parametrize("kwargs", ({}, {"description": "Test Dataset"}))
+def test_creating_dataset_from_x_y_arrays(train_size, kwargs):
     X, y = make_classification()
-    dataset = Dataset.from_arrays(X, y, train_size=train_size)
+    dataset = Dataset.from_arrays(X, y, train_size=train_size, **kwargs)
     assert len(dataset) == int(train_size * len(X))
+    for k, v in kwargs.items():
+        assert getattr(dataset, k) == v
 
 
 def test_creating_grouped_dataset_from_sklearn(train_size):
@@ -62,13 +65,16 @@ def test_creating_grouped_dataset_subsclassfrom_sklearn(train_size):
     assert len(dataset) == n_groups
 
 
-def test_creating_grouped_dataset_from_x_y_arrays(train_size):
+@pytest.mark.parametrize("kwargs", ({}, {"description": "Test Dataset"}))
+def test_creating_grouped_dataset_from_x_y_arrays(train_size, kwargs):
     X, y = make_classification()
     data_groups = np.random.randint(
         low=0, high=3, size=int(train_size * len(X))
     ).flatten()
     n_groups = len(np.unique(data_groups))
     dataset = GroupedDataset.from_arrays(
-        X, y, data_groups=data_groups, train_size=train_size
+        X, y, data_groups=data_groups, train_size=train_size, **kwargs
     )
     assert len(dataset) == n_groups
+    for k, v in kwargs.items():
+        assert getattr(dataset, k) == v


### PR DESCRIPTION
### Description

This PR closes #252 

### Changes

- Adds `kwargs` parameter to `from_array` and `from_sklearn` Dataset and GroupedDataset class methods.

### Checklist

- [x] Wrote Unit tests (if necessary)
- [ ] Updated Documentation (if necessary)
- [x] Updated Changelog
- [ ] If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`
