### PR TITLE
Add .gitattributes with override for notebook files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Override jupyter in Github language stats
+# for a more accurate estimate of repository's code languages
+# https://github.com/github/linguist/blob/master/docs/overrides.md#generated-code
+*.ipynb linguist-generated


### PR DESCRIPTION
### Description

This PR fixes the Github language statistics.

### Changes

- Add a `.gitattributes` file with one entry to ignore jupyter notebook files in Github statistics.

### Checklist

- [ ] Wrote Unit tests (if necessary)
- [ ] Updated Documentation (if necessary)
- [ ] Updated Changelog
- [ ] If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`
