### PR TITLE
Improvements to ValuationResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fixes in `ValuationResult`: bugs around data names, semantics of
+  `empty()`, new method `zeros()` and normalised random values
+  [PR #327](https://github.com/appliedAI-Initiative/pyDVL/pull/327)
 - **New method**: Implements generalised semi-values for data valuation,
   including Data Banzhaf and Beta Shapley, with configurable sampling strategies
   [PR #319](https://github.com/appliedAI-Initiative/pyDVL/pull/319)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-deprecation>=2.0.6
+pyDeprecate>=0.3.2
 numpy>=1.20
 pandas>=1.3
 scikit-learn

--- a/src/pydvl/value/least_core/__init__.py
+++ b/src/pydvl/value/least_core/__init__.py
@@ -24,8 +24,6 @@ import warnings
 from enum import Enum
 from typing import Optional
 
-from deprecation import DeprecatedWarning
-
 from pydvl.utils.utility import Utility
 from pydvl.value.least_core.montecarlo import *
 from pydvl.value.least_core.naive import *
@@ -84,11 +82,9 @@ def compute_least_core_values(
     # TODO: remove this before releasing version 0.6.0
     if kwargs:
         warnings.warn(
-            DeprecatedWarning(
-                "Passing solver options as kwargs",
-                deprecated_in="0.5.1",
-                removed_in="0.6.0",
-                details="Use solver_options instead.",
+            DeprecationWarning(
+                "Passing solver options as kwargs was deprecated in 0.5.1, will "
+                "be removed in 0.6.0. `Use solver_options` instead."
             )
         )
         if solver_options is None:

--- a/src/pydvl/value/least_core/common.py
+++ b/src/pydvl/value/least_core/common.py
@@ -5,7 +5,6 @@ from typing import List, NamedTuple, Optional, Sequence, Tuple
 
 import cvxpy as cp
 import numpy as np
-from deprecation import DeprecatedWarning
 from numpy.typing import NDArray
 
 from pydvl.utils import MapReduceJob, ParallelConfig, Status, Utility
@@ -57,11 +56,10 @@ def lc_solve_problem(
     # TODO: remove this before releasing version 0.6.0
     if options:
         warnings.warn(
-            DeprecatedWarning(
-                "Passing solver options as kwargs",
-                deprecated_in="0.5.1",
-                removed_in="0.6.0",
-                details="Use solver_options instead.",
+            DeprecationWarning(
+                "Passing solver options as kwargs was deprecated in "
+                "0.5.1, will be removed in 0.6.0. `Use solver_options` "
+                "instead."
             )
         )
         if solver_options is None:
@@ -256,10 +254,7 @@ def _solve_least_core_linear_program(
     e = cp.Variable()
 
     objective = cp.Minimize(e)
-    constraints = [
-        A_eq @ x == b_eq,
-        (A_lb @ x + e * np.ones(len(A_lb))) >= b_lb,
-    ]
+    constraints = [A_eq @ x == b_eq, (A_lb @ x + e * np.ones(len(A_lb))) >= b_lb]
 
     if non_negative_subsidy:
         constraints += [e >= 0]
@@ -333,10 +328,7 @@ def _solve_egalitarian_least_core_quadratic_program(
     x = cp.Variable(n_variables)
 
     objective = cp.Minimize(cp.norm2(x))
-    constraints = [
-        A_eq @ x == b_eq,
-        (A_lb @ x + subsidy * np.ones(len(A_lb))) >= b_lb,
-    ]
+    constraints = [A_eq @ x == b_eq, (A_lb @ x + subsidy * np.ones(len(A_lb))) >= b_lb]
     problem = cp.Problem(objective, constraints)
 
     try:

--- a/src/pydvl/value/least_core/montecarlo.py
+++ b/src/pydvl/value/least_core/montecarlo.py
@@ -3,7 +3,6 @@ import warnings
 from typing import Iterable, Optional
 
 import numpy as np
-from deprecation import DeprecatedWarning
 
 from pydvl.utils.config import ParallelConfig
 from pydvl.utils.numeric import random_powerset
@@ -17,10 +16,7 @@ from pydvl.value.result import ValuationResult
 logger = logging.getLogger(__name__)
 
 
-__all__ = [
-    "montecarlo_least_core",
-    "mclc_prepare_problem",
-]
+__all__ = ["montecarlo_least_core", "mclc_prepare_problem"]
 
 
 def montecarlo_least_core(
@@ -68,11 +64,10 @@ def montecarlo_least_core(
     # TODO: remove this before releasing version 0.6.0
     if options:
         warnings.warn(
-            DeprecatedWarning(
-                "Passing solver options as kwargs",
-                deprecated_in="0.5.1",
-                removed_in="0.6.0",
-                details="Use solver_options instead.",
+            DeprecationWarning(
+                "Passing solver options as kwargs was deprecated in "
+                "0.5.1, will be removed in 0.6.0. `Use solver_options` "
+                "instead."
             )
         )
         if solver_options is None:

--- a/src/pydvl/value/least_core/naive.py
+++ b/src/pydvl/value/least_core/naive.py
@@ -3,7 +3,6 @@ import warnings
 from typing import Optional
 
 import numpy as np
-from deprecation import DeprecatedWarning
 
 from pydvl.utils import Utility, maybe_progress, powerset
 from pydvl.value.least_core.common import LeastCoreProblem, lc_solve_problem
@@ -61,11 +60,10 @@ def exact_least_core(
     # TODO: remove this before releasing version 0.6.0
     if options:
         warnings.warn(
-            DeprecatedWarning(
-                "Passing solver options as kwargs",
-                deprecated_in="0.5.1",
-                removed_in="0.6.0",
-                details="Use solver_options instead.",
+            DeprecationWarning(
+                "Passing solver options as kwargs was deprecated in "
+                "0.5.1, will "
+                "be removed in 0.6.0. `Use solver_options` instead."
             )
         )
         if solver_options is None:

--- a/src/pydvl/value/result.py
+++ b/src/pydvl/value/result.py
@@ -27,6 +27,8 @@ returned. These objects can be compared with the usual operators, which take
 only the :attr:`ValueItem.value` into account.
 
 """
+from __future__ import annotations
+
 import collections.abc
 import logging
 from dataclasses import dataclass
@@ -34,12 +36,14 @@ from functools import total_ordering
 from numbers import Integral
 from typing import (
     Any,
-    Generator,
+    Generic,
     Iterable,
+    Iterator,
     List,
     Literal,
     Optional,
     Sequence,
+    TypeVar,
     Union,
     cast,
     overload,
@@ -57,14 +61,18 @@ try:
 except ImportError:
     pass
 
-__all__ = ["ValuationResult", "ValueItem"]
+__all__ = ["ValuationResult", "ValueItem", "IndexT", "NameT"]
 
 logger = logging.getLogger(__name__)
+
+# TODO: Move to value.types once it's there
+IndexT = TypeVar("IndexT", bound=np.int_)
+NameT = TypeVar("NameT", bound=Any)
 
 
 @total_ordering
 @dataclass
-class ValueItem:
+class ValueItem(Generic[IndexT, NameT]):
     """The result of a value computation for one datum.
 
     ``ValueItems`` can be compared with the usual operators, forming a total
@@ -77,9 +85,9 @@ class ValueItem:
 
     #: Index of the sample with this value in the original
     #  :class:`~pydvl.utils.dataset.Dataset`
-    index: int
+    index: IndexT
     #: Name of the sample if it was provided. Otherwise, `str(index)`
-    name: str
+    name: NameT
     #: The value
     value: float
     #: Variance of the value if it was computed with an approximate method
@@ -93,7 +101,7 @@ class ValueItem:
     def __eq__(self, other):
         return self.value == other.value
 
-    def __index__(self) -> int:
+    def __index__(self) -> IndexT:
         return self.index
 
     @property
@@ -104,7 +112,9 @@ class ValueItem:
         return float(np.sqrt(self.variance / self.count).item())
 
 
-class ValuationResult(collections.abc.Sequence):
+class ValuationResult(
+    collections.abc.Sequence, Iterable[ValueItem[IndexT, NameT]], Generic[IndexT, NameT]
+):
     """Objects of this class hold the results of valuation algorithms.
 
     These include indices in the original :class:`Dataset`, any data names (e.g.
@@ -179,12 +189,12 @@ class ValuationResult(collections.abc.Sequence):
     :raise ValueError: If input arrays have mismatching lengths.
     """
 
-    _indices: NDArray[np.int_]
+    _indices: NDArray[IndexT]
     _values: NDArray[np.float_]
     _counts: NDArray[np.int_]
     _variances: NDArray[np.float_]
     _data: Dataset
-    _names: NDArray[np.str_]
+    _names: NDArray[NameT]
     _algorithm: str
     _status: Status
     # None for unsorted, True for ascending, False for descending
@@ -197,8 +207,8 @@ class ValuationResult(collections.abc.Sequence):
         values: NDArray[np.float_],
         variances: Optional[NDArray[np.float_]] = None,
         counts: Optional[NDArray[np.int_]] = None,
-        indices: Optional[NDArray[np.int_]] = None,
-        data_names: Optional[Union[Sequence[str], NDArray[np.str_]]] = None,
+        indices: Optional[NDArray[IndexT]] = None,
+        data_names: Optional[Sequence[NameT] | NDArray[NameT]] = None,
         algorithm: str = "",
         status: Status = Status.Pending,
         sort: bool = False,
@@ -220,8 +230,11 @@ class ValuationResult(collections.abc.Sequence):
         self._extra_values = extra_values or {}
 
         if data_names is None:
-            data_names = [str(i) for i in range(len(self._values))]
-        self._names = np.array(data_names, dtype=np.str_)
+            self._names = np.array([str(i) for i in range(len(self._values))])
+        elif not isinstance(data_names, np.ndarray):
+            self._names = np.array(data_names)
+        else:
+            self._names = data_names.copy()
         if len(np.unique(self._names)) != len(self._names):
             raise ValueError("Data names must be unique")
 
@@ -285,7 +298,7 @@ class ValuationResult(collections.abc.Sequence):
         return self._counts[self._sort_positions]
 
     @property
-    def indices(self) -> NDArray[np.int_]:
+    def indices(self) -> NDArray[IndexT]:
         """The indices for the values, possibly sorted.
 
         If the object is unsorted, then these are the same as declared at
@@ -294,7 +307,7 @@ class ValuationResult(collections.abc.Sequence):
         return self._indices[self._sort_positions]
 
     @property
-    def names(self) -> NDArray[np.str_]:
+    def names(self) -> NDArray[NameT]:
         """The names for the values, possibly sorted.
         If the object is unsorted, then these are the same as declared at
         construction or ``np.arange(len(values))`` if none were passed.
@@ -347,8 +360,8 @@ class ValuationResult(collections.abc.Sequence):
                 raise IndexError(f"Index {key} out of range (0, {len(self)}).")
             idx = self._sort_positions[key]
             return ValueItem(
-                int(self._indices[idx]),
-                str(self._names[idx]),
+                self._indices[idx],
+                self._names[idx],
                 float(self._values[idx]),
                 float(self._variances[idx]),
                 int(self._counts[idx]),
@@ -391,7 +404,7 @@ class ValuationResult(collections.abc.Sequence):
         else:
             raise TypeError("Indices must be integers, iterable or slices")
 
-    def __iter__(self) -> Generator[ValueItem, Any, None]:
+    def __iter__(self) -> Iterator[ValueItem[IndexT, NameT]]:
         """Iterate over the results returning :class:`ValueItem` objects.
         To sort in place before iteration, use :meth:`sort`.
         """
@@ -443,7 +456,7 @@ class ValuationResult(collections.abc.Sequence):
             raise NotImplementedError(
                 f"Cannot combine ValuationResult with {type(other)}"
             )
-        if self.algorithm != other.algorithm:
+        if self.algorithm and self.algorithm != other.algorithm:
             raise ValueError("Cannot combine results from different algorithms")
 
     def __add__(self, other: "ValuationResult") -> "ValuationResult":
@@ -478,7 +491,7 @@ class ValuationResult(collections.abc.Sequence):
 
         self._check_compatible(other)
 
-        indices = np.union1d(self._indices, other._indices)
+        indices = np.union1d(self._indices, other._indices).astype(self._indices.dtype)
         this_pos = np.searchsorted(indices, self._indices)
         other_pos = np.searchsorted(indices, other._indices)
 
@@ -501,18 +514,6 @@ class ValuationResult(collections.abc.Sequence):
         # Sample variance of n+m samples from two sample variances of n and m samples
         vnm = (n * (vn + xn**2) + m * (vm + xm**2)) / (n + m) - xnm**2
 
-        if self._names.dtype != other._names.dtype:
-            raise ValueError(f"Mismatching name dtypes in ValuationResults")
-
-        this_names = np.empty_like(indices, dtype=object)
-        other_names = np.empty_like(indices, dtype=object)
-        this_names[this_pos] = self._names
-        other_names[other_pos] = other._names
-        names = np.where(this_names, this_names, other_names).astype(self._names.dtype)
-        both = np.where((this_names != None) & (other_names != None))
-        if np.any(other_names[both] != this_names[both]):
-            raise ValueError(f"Mismatching names in ValuationResults")
-
         if np.any(vnm < 0):
             if np.any(vnm < -1e-6):
                 logger.warning(
@@ -520,6 +521,34 @@ class ValuationResult(collections.abc.Sequence):
                     f"Negative sample variances clipped to 0 in {vnm}"
                 )
             vnm[np.where(vnm < 0)] = 0
+
+        # Merging of names:
+        # If an index has the same name in both results, it must be the same.
+        # If an index has a name in one result but not the other, the name is
+        # taken from the result with the name.
+        if self._names.dtype != other._names.dtype:
+            if np.can_cast(other._names.dtype, self._names.dtype, casting="safe"):
+                other._names = other._names.astype(self._names.dtype)
+                logger.warning(
+                    f"Casting ValuationResult.names from {other._names.dtype} to {self._names.dtype}"
+                )
+            else:
+                raise TypeError(
+                    f"Cannot cast ValuationResult.names from "
+                    f"{other._names.dtype} to {self._names.dtype}"
+                )
+
+        this_names = np.empty_like(indices, dtype=object)
+        other_names = np.empty_like(indices, dtype=object)
+        this_names[this_pos] = self._names
+        other_names[other_pos] = other._names
+        both = np.where(this_pos == other_pos)
+        names = np.empty_like(indices, dtype=self._names.dtype)
+        names[this_pos] = self._names
+        names[other_pos] = other._names
+
+        if np.any(other_names[both] != this_names[both]):
+            raise ValueError(f"Mismatching names in ValuationResults")
 
         return ValuationResult(
             algorithm=self.algorithm or other.algorithm or "",
@@ -550,7 +579,7 @@ class ValuationResult(collections.abc.Sequence):
             self._values[pos], self._variances[pos], self._counts[pos], new_value
         )
         self[pos] = ValueItem(
-            index=idx,
+            index=cast(IndexT, idx),
             name=self._names[pos],
             value=val,
             variance=var,
@@ -604,16 +633,21 @@ class ValuationResult(collections.abc.Sequence):
         return df
 
     @classmethod
-    def from_random(cls, size: int) -> "ValuationResult":
+    def from_random(cls, size: int, **kwargs) -> "ValuationResult":
         """Creates a :class:`ValuationResult` object and fills it
         with an array of random values of the given size uniformly sampled
         from the range [-1, 1].
 
         :param size: Number of values to generate
-        :return: An instance of :class:`ValuationResult`
+        :param kwargs: Additional options to pass to the constructor of
+            :class:`ValuationResult`. Use to override status, names, etc.
+        :return: A valuation result with its status set to :attr:`Status.Converged`
+            by default.
         """
         values = np.random.uniform(low=-1.0, high=1.0, size=size)
-        return cls(algorithm="random", status=Status.Converged, values=values)
+        options = dict(values=values, status=Status.Converged, algorithm="random")
+        options.update(kwargs)
+        return cls(**options)  # type: ignore
 
     @classmethod
     def empty(

--- a/src/pydvl/value/result.py
+++ b/src/pydvl/value/result.py
@@ -653,7 +653,7 @@ class ValuationResult(
     ) -> "ValuationResult":
         """Creates a :class:`ValuationResult` object and fills it with an array
         of random values from a uniform distribution in [-1,1]. The values can
-        be to sum to a given total number (doing so will change their range).
+        be made to sum up to a given total number (doing so will change their range).
 
         :param size: Number of values to generate
         :param total: If set, the values are normalized to sum to this number

--- a/src/pydvl/value/result.py
+++ b/src/pydvl/value/result.py
@@ -501,11 +501,14 @@ class ValuationResult(collections.abc.Sequence):
         # Sample variance of n+m samples from two sample variances of n and m samples
         vnm = (n * (vn + xn**2) + m * (vm + xm**2)) / (n + m) - xnm**2
 
+        if self._names.dtype != other._names.dtype:
+            raise ValueError(f"Mismatching name dtypes in ValuationResults")
+
         this_names = np.empty_like(indices, dtype=object)
         other_names = np.empty_like(indices, dtype=object)
         this_names[this_pos] = self._names
         other_names[other_pos] = other._names
-        names = np.where(this_names, this_names, other_names)
+        names = np.where(this_names, this_names, other_names).astype(self._names.dtype)
         both = np.where((this_names != None) & (other_names != None))
         if np.any(other_names[both] != this_names[both]):
             raise ValueError(f"Mismatching names in ValuationResults")

--- a/src/pydvl/value/semivalues.py
+++ b/src/pydvl/value/semivalues.py
@@ -102,9 +102,10 @@ def _semivalues(
     :return: Object with the results.
     """
     n = len(u.data.indices)
-    result = ValuationResult.empty(
+    result = ValuationResult.zeros(
         algorithm=f"semivalue-{str(sampler)}-{coefficient.__name__}",
         indices=sampler.indices,
+        data_names=[u.data.data_names[i] for i in sampler.indices],
     )
 
     samples = takewhile(lambda _: not done(result), sampler)

--- a/src/pydvl/value/shapley/actor.py
+++ b/src/pydvl/value/shapley/actor.py
@@ -77,7 +77,7 @@ class ShapleyCoordinator(Coordinator):
             reported yet, returns ``None``.
         """
         if len(self.worker_results) == 0:
-            return ValuationResult.empty()
+            return ValuationResult.empty()  # type: ignore
 
         # FIXME: inefficient, possibly unstable
         totals: ValuationResult = reduce(operator.add, self.worker_results)
@@ -161,7 +161,7 @@ class ShapleyWorker(Worker):
         terminating if it's ``True``.
         """
         while True:
-            acc = ValuationResult.empty(algorithm=self.algorithm)
+            acc = ValuationResult.empty()
             start_time = time()
             while (time() - start_time) < self.update_period:
                 if self.coordinator.is_done():

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -179,7 +179,7 @@ def _combinatorial_montecarlo_shapley(
     correction = 2 ** (n - 1) / n
     result = ValuationResult.empty(
         algorithm="combinatorial_montecarlo_shapley",
-        indices=indices,
+        indices=np.array(indices, dtype=np.int_),
         data_names=[u.data.data_names[i] for i in indices],
     )
 

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -79,7 +79,7 @@ def _permutation_montecarlo_shapley(
     :param job_id: id to use for reporting progress (e.g. to place progres bars)
     :return: An object with the results
     """
-    result = ValuationResult.empty(
+    result = ValuationResult.zeros(
         algorithm=algorithm_name, indices=u.data.indices, data_names=u.data.data_names
     )
 
@@ -177,7 +177,7 @@ def _combinatorial_montecarlo_shapley(
     # powerset of a set with n-1 elements has mass 2^{n-1} over each subset. The
     # additional factor n corresponds to the one in the Shapley definition
     correction = 2 ** (n - 1) / n
-    result = ValuationResult.empty(
+    result = ValuationResult.zeros(
         algorithm="combinatorial_montecarlo_shapley",
         indices=np.array(indices, dtype=np.int_),
         data_names=[u.data.data_names[i] for i in indices],

--- a/src/pydvl/value/shapley/owen.py
+++ b/src/pydvl/value/shapley/owen.py
@@ -54,7 +54,7 @@ def _owen_sampling_shapley(
 
     result = ValuationResult.empty(
         algorithm="owen_sampling_shapley_" + str(method),
-        indices=indices,
+        indices=np.array(indices, dtype=np.int_),
         data_names=[u.data.data_names[i] for i in indices],
     )
 

--- a/src/pydvl/value/shapley/owen.py
+++ b/src/pydvl/value/shapley/owen.py
@@ -52,7 +52,7 @@ def _owen_sampling_shapley(
     q_stop = {OwenAlgorithm.Standard: 1.0, OwenAlgorithm.Antithetic: 0.5}
     q_steps = np.linspace(start=0, stop=q_stop[method], num=max_q)
 
-    result = ValuationResult.empty(
+    result = ValuationResult.zeros(
         algorithm="owen_sampling_shapley_" + str(method),
         indices=np.array(indices, dtype=np.int_),
         data_names=[u.data.data_names[i] for i in indices],

--- a/src/pydvl/value/stopping.py
+++ b/src/pydvl/value/stopping.py
@@ -34,9 +34,8 @@ from time import time
 from typing import Callable, Optional, Type
 
 import numpy as np
-from deprecation import deprecated
+from deprecate import deprecated, void
 from numpy.typing import NDArray
-from scipy.stats import norm
 
 from pydvl.utils import Status
 from pydvl.value import ValuationResult
@@ -221,14 +220,10 @@ class AbsoluteStandardError(StoppingCriterion):
         return Status.Pending
 
 
-@deprecated(
-    deprecated_in="0.6.0",
-    removed_in="0.7.0",
-    details="This stopping criterion has been deprecated. "
-    "Use AbsoluteStandardError instead",
-)
 class StandardError(AbsoluteStandardError):
-    pass
+    @deprecated(target=AbsoluteStandardError, deprecated_in="0.5.1", remove_in="0.7.0")
+    def __init__(self, *args, **kwargs):
+        void(*args, **kwargs)
 
 
 class MaxChecks(StoppingCriterion):

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import operator
 import pickle
@@ -238,10 +240,20 @@ def test_extra_values(extra_values):
         assert k in repr_string
 
 
-@pytest.mark.parametrize("size", [0, 1, 10, 500])
-def test_from_random_creation(size):
-    result = ValuationResult.from_random(size)
+@pytest.mark.parametrize("size", [1, 10])
+@pytest.mark.parametrize("total", [None, 1.0, -1.0])
+def test_from_random_creation(size: int, total: float | None):
+    result = ValuationResult.from_random(size=size, total=total)
     assert len(result) == size
+    assert result.status == Status.Converged
+    assert result.algorithm == "random"
+    if total is not None:
+        assert np.isclose(np.sum(result.values), total)
+
+
+def test_from_random_creation_errors():
+    with pytest.raises(ValueError):
+        ValuationResult.from_random(size=0)
 
 
 def test_adding_random():

--- a/tests/utils/test_dataset.py
+++ b/tests/utils/test_dataset.py
@@ -83,3 +83,29 @@ def test_creating_grouped_dataset_from_x_y_arrays(train_size, kwargs):
 
     with pytest.raises(ValueError):
         GroupedDataset.from_arrays(X, y, data_groups=data_groups[len(X) // 2 :])
+
+
+def test_grouped_dataset_results():
+    """Test that data names are preserved in valuation results"""
+    X, y = make_classification()
+    train_size = 0.5
+    data_groups = np.random.randint(
+        low=0, high=3, size=int(train_size * len(X)), dtype=np.int_
+    ).flatten()
+    dataset = GroupedDataset.from_arrays(
+        X, y, data_groups=data_groups, train_size=train_size
+    )
+
+    from pydvl.value import ValuationResult
+
+    v = ValuationResult.zeros(indices=dataset.indices, data_names=dataset.data_names)
+    v2 = ValuationResult(
+        indices=dataset.indices,
+        values=np.ones(len(dataset)),
+        variances=np.zeros(len(dataset)),
+        data_names=dataset.data_names,
+    )
+    v += v2
+    assert np.all(v.values == 1)
+    assert np.all(v.names == np.array(dataset.data_names))
+    assert np.all([isinstance(x, np.int_) for x in v.names])

--- a/tests/utils/test_dataset.py
+++ b/tests/utils/test_dataset.py
@@ -3,6 +3,7 @@ import pytest
 from sklearn.datasets import load_wine, make_classification
 
 from pydvl.utils.dataset import Dataset, GroupedDataset
+from pydvl.value.result import ValuationResult
 
 
 @pytest.fixture(scope="module", params=[0.1, 0.5, 0.8])
@@ -95,8 +96,6 @@ def test_grouped_dataset_results():
     dataset = GroupedDataset.from_arrays(
         X, y, data_groups=data_groups, train_size=train_size
     )
-
-    from pydvl.value import ValuationResult
 
     v = ValuationResult.zeros(indices=dataset.indices, data_names=dataset.data_names)
     v2 = ValuationResult(


### PR DESCRIPTION
<!--
Thanks for making a contribution! 
Please make sure you have read the contributing guide: 
https://github.com/appliedAI-Initiative/pyDVL/blob/develop/CONTRIBUTING.md
-->

### Description

This PR closes #285, closes #256 and fixes several bugs with ValuationResult

### Changes

- Introduces pyDeprecation as replacement for deprecation module, providing finer-grained control, deprecated parameters and redirects
- Introduces `ValuationResult.zeros()` and restores the original semantics of `ValuationResult.empty()`.
- Fixes a number of issues with data types when adding `ValuationResults` (automatic conversions and sometimes potential loss of information)
- Tests that results work well with `GroupedDataset`
- 

### Checklist

- [x] Wrote Unit tests (if necessary)
- [x] Updated Documentation (if necessary)
- [x] Updated Changelog
- [ ] If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`
