### PR TITLE
Fix release script not triggering action to publish in PyPI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,6 +10,10 @@ on:
         description: Why did you trigger the pipeline?
         required: False
         default: Check if it runs again due to external changes
+      tag:
+        description: Tag for which a package should be published
+        type: string
+        required: false
 
 env:
   PY_COLORS: 1
@@ -23,19 +27,35 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Fail if manually triggered workflow is not on 'master' branch
-        if: github.event_name == 'workflow_dispatch' && github.ref_name != 'master'
-        run: exit -1
+      - name: Fail if manually triggered workflow does not have 'tag' input
+        if: github.event_name == 'workflow_dispatch' && inputs.tag == ''
+        run: |
+          echo "Input 'tag' should not be empty"
+          exit -1
+      - name: Extract branch name from input
+        id: get_branch_name_input
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          export BRANCH_NAME=$(git log -1 --format='%D' ${{ inputs.tag }} | sed -e 's/.*origin\/\(.*\).*/\1/')
+          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
       - name: Extract branch name from tag
-        id: get_branch_name
+        id: get_branch_name_tag
         if: github.ref_type == 'tag'
         run: |
-          export BRANCH_NAME=$(git log -1 --format='%D' $GITHUB_REF | sed -e 's/.*origin\/\(.*\),.*/\1/')
-          echo ::set-output name=branch_name::${BRANCH_NAME}
+          export BRANCH_NAME=$(git log -1 --format='%D' $GITHUB_REF | sed -e 's/.*origin\/\(.*\).*/\1/')
+          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
         shell: bash
       - name: Fail if tag is not on 'master' branch
-        if: github.ref_type == 'tag' && steps.get_branch_name.outputs.branch_name != 'master'
-        run: exit -1
+        if: ${{ steps.get_branch_name_tag.outputs.branch_name != 'master' && steps.get_branch_name_input.outputs.branch_name != 'master' }}
+        run: |
+          echo "Tag is on branch ${{ steps.get_branch_name.outputs.branch_name }}"
+          echo "Should be on Master branch instead"
+          exit -1
+      - name: Fail if running locally
+        if: ${{ !github.event.act }} # skip during local actions testing
+        run: |
+          echo "Running action locally. Failing"
+          exit -1
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: Upload Python Package to PyPI
+name: Publish Python Package to PyPI
 
 on:
   push:
@@ -19,10 +19,10 @@ env:
   PY_COLORS: 1
 
 jobs:
-  deploy:
+  publish:
     runs-on: ubuntu-latest
     concurrency:
-      group: deploy
+      group: publish
     steps:
       - uses: actions/checkout@v3
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,6 +261,101 @@ sizeable amount of time, so care must be taken not to overdo it:
 2. We try not to trigger CI pipelines when unnecessary (see [Skipping CI
 runs](#skipping-ci-runs)).
 
+### Running Github Actions locally
+
+To run Github Actions locally we use [act](https://github.com/nektos/act).
+It uses the workflows defined in `.github/workflows` and determines
+the set of actions that need to be run. It uses the Docker API
+to either pull or build the necessary images, as defined
+in our workflow files and finally determines the execution path
+based on the dependencies that were defined.
+
+Once it has the execution path, it then uses the Docker API
+to run containers for each action based on the images prepared earlier.
+The [environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) 
+and [filesystem](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#file-systems) are all configured to match
+what GitHub provides.
+
+You can install it manually using:
+
+```shell
+curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash -s -- -d -b ~/bin 
+```
+
+And then simply add it to your PATH variable: `PATH=~/bin:$PATH`
+
+Refer to its official
+[readme](https://github.com/nektos/act#installation-through-package-managers)
+for more installation options.
+
+#### Cheatsheat
+
+```shell
+# List all actions for all events:
+act -l
+
+# List the actions for a specific event:
+act workflow_dispatch -l
+
+# List the actions for a specific job:
+act -j lint -l
+
+# Run the default (`push`) event:
+act
+
+# Run a specific event:
+act pull_request
+
+# Run a specific job:
+act -j lint
+
+# Collect artifacts to the /tmp/artifacts folder:
+act --artifact-server-path /tmp/artifacts
+
+# Run a job in a specific workflow (useful if you have duplicate job names)
+act -j lint -W .github/workflows/tox.yml
+
+# Run in dry-run mode:
+act -n
+
+# Enable verbose-logging (can be used with any of the above commands)
+act -v
+```
+
+#### Example
+
+To run the `deploy` job (the toughest one to test) with tag 'v0.6.0' 
+you would simply use:
+
+```shell
+act push -j deploy --eventpath events.json
+```
+
+With `events.json` containing:
+
+```json
+{
+  "ref": "refs/tags/v0.6.0"
+}
+```
+
+To instead run it as it were manually triggered (i.e. `workflow_dispatch`)
+you would instead use:
+
+```shell
+act workflow_dispatch -j deploy --eventpath events.json
+```
+
+With `events.json` containing:
+
+```json
+{
+  "inputs": {
+    "tag": "v0.6.0"
+  }
+}
+```
+
 ### Skipping CI runs
 
 One sometimes would like to skip CI for certain commits (e.g. updating the
@@ -348,10 +443,10 @@ create a new release manually by following these steps:
 8. Pour yourself a cup of coffee, you earned it! :coffee: :sparkles:
 9. A package will be automatically created and published from CI to PyPI.
 
-### CI and requirements for releases
+### CI and requirements for publishing
 
-In order to release new versions of the package from the development branch, the
-CI pipeline requires the following secret variables set up:
+In order to publish new versions of the package from the development branch,
+the CI pipeline requires the following secret variables set up:
 
 ```
 TEST_PYPI_USERNAME
@@ -367,13 +462,13 @@ The last 2 are used in the [publish.yaml](.github/workflows/publish.yaml) CI
 workflow to publish packages to [PyPI](https://pypi.org/) from `develop` after
 a GitHub release.
 
-#### Release to TestPyPI
+#### Publish to TestPyPI
 
-We use [bump2version](https://pypi.org/project/bump2version/) to bump the build
-part of the version number, create a tag and push it from CI.
+We use [bump2version](https://pypi.org/project/bump2version/) to bump
+the build part of the version number publish a package to TestPyPI from CI.
 
 To do that, we use 2 different tox environments:
 
 - **bump-dev-version**: Uses bump2version to bump the dev version,
-  without committing  the new version or creating a corresponding git tag.
+  without committing the new version or creating a corresponding git tag.
 - **publish-test-package**: Builds and publishes a package to TestPyPI


### PR DESCRIPTION
### Description

This PR closes #273 and adds a few improvements and documentation.

### Changes

- Fix publish job not correctly triggering when a new tag is pushed.
- Add `tag` input field when manually triggering the publish job.
- Document using [act]() to run github actions locally with examples.
- Change a few words for consistency.

### Checklist

- [ ] Wrote Unit tests (if necessary)
- [X] Updated Documentation (if necessary)
- [ ] Updated Changelog
- [ ] If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`
