### PR TITLE
Fix creating grouped dataset object from arrays or from sklearn dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix creation of GroupedDataset objects using the `from_arrays`
+  and `from_sklearn` class methods 
+  [PR #324](https://github.com/appliedAI-Initiative/pyDVL/pull/334)
 - Fix release job not triggering on CI when a new tag is pushed
   [PR #331](https://github.com/appliedAI-Initiative/pyDVL/pull/331)
 - Added alias `ApproShapley` from Castro et al. 2009 for permutation Shapley

--- a/src/pydvl/utils/dataset.py
+++ b/src/pydvl/utils/dataset.py
@@ -479,10 +479,20 @@ class GroupedDataset(Dataset):
             raise ValueError(
                 "data_groups must be provided when constructing a GroupedDataset"
             )
-        dataset = Dataset.from_sklearn(
-            data, train_size, random_state, stratify_by_target, **kwargs
+
+        x_train, x_test, y_train, y_test, data_groups_train, _ = train_test_split(
+            data.data,
+            data.target,
+            data_groups,
+            train_size=train_size,
+            random_state=random_state,
+            stratify=data.target if stratify_by_target else None,
         )
-        return cls.from_dataset(dataset, data_groups)  # type: ignore
+
+        dataset = Dataset(
+            x_train=x_train, y_train=y_train, x_test=x_test, y_test=y_test, **kwargs
+        )
+        return cls.from_dataset(dataset, data_groups_train)  # type: ignore
 
     @classmethod
     def from_arrays(
@@ -527,10 +537,18 @@ class GroupedDataset(Dataset):
             raise ValueError(
                 "data_groups must be provided when constructing a GroupedDataset"
             )
-        dataset = Dataset.from_arrays(
-            X, y, train_size, random_state, stratify_by_target, **kwargs
+        x_train, x_test, y_train, y_test, data_groups_train, _ = train_test_split(
+            X,
+            y,
+            data_groups,
+            train_size=train_size,
+            random_state=random_state,
+            stratify=y if stratify_by_target else None,
         )
-        return cls.from_dataset(dataset, data_groups)
+        dataset = Dataset(
+            x_train=x_train, y_train=y_train, x_test=x_test, y_test=y_test, **kwargs
+        )
+        return cls.from_dataset(dataset, data_groups_train)
 
     @classmethod
     def from_dataset(

--- a/tests/utils/test_dataset.py
+++ b/tests/utils/test_dataset.py
@@ -101,9 +101,7 @@ def test_grouped_dataset_results():
     """Test that data names are preserved in valuation results"""
     X, y = make_classification()
     train_size = 0.5
-    data_groups = np.random.randint(
-        low=0, high=3, size=int(train_size * len(X)), dtype=np.int_
-    ).flatten()
+    data_groups = np.random.randint(low=0, high=3, size=len(X)).flatten()
     dataset = GroupedDataset.from_arrays(
         X, y, data_groups=data_groups, train_size=train_size
     )

--- a/tests/utils/test_dataset.py
+++ b/tests/utils/test_dataset.py
@@ -39,16 +39,23 @@ def test_creating_dataset_from_x_y_arrays(train_size, kwargs):
 
 def test_creating_grouped_dataset_from_sklearn(train_size):
     data = load_wine()
-    data_groups = np.random.randint(
-        low=0, high=3, size=int(train_size * len(data.data))
-    ).flatten()
+    data_groups = np.random.randint(low=0, high=3, size=len(data.data)).flatten()
     n_groups = len(np.unique(data_groups))
     dataset = GroupedDataset.from_sklearn(
         data, data_groups=data_groups, train_size=train_size
     )
     assert len(dataset) == n_groups
+
+
+def test_creating_grouped_dataset_from_sklearn_failure(train_size):
     with pytest.raises(ValueError):
-        GroupedDataset.from_sklearn(data, data_groups=data_groups[len(data) // 2 :])
+        data = load_wine()
+        # The length of data groups should be equal to that of data
+        data_groups_length = np.random.randint(low=0, high=len(data.data) - 1)
+        data_groups = np.random.randint(
+            low=0, high=3, size=data_groups_length
+        ).flatten()
+        GroupedDataset.from_sklearn(data, data_groups=data_groups)
 
 
 def test_creating_grouped_dataset_subsclassfrom_sklearn(train_size):
@@ -57,9 +64,7 @@ def test_creating_grouped_dataset_subsclassfrom_sklearn(train_size):
     class TestGroupedDataset(GroupedDataset):
         ...
 
-    data_groups = np.random.randint(
-        low=0, high=3, size=int(train_size * len(data.data))
-    ).flatten()
+    data_groups = np.random.randint(low=0, high=3, size=len(data.data)).flatten()
     n_groups = len(np.unique(data_groups))
     dataset = TestGroupedDataset.from_sklearn(
         data, data_groups=data_groups, train_size=train_size
@@ -71,9 +76,7 @@ def test_creating_grouped_dataset_subsclassfrom_sklearn(train_size):
 @pytest.mark.parametrize("kwargs", ({}, {"description": "Test Dataset"}))
 def test_creating_grouped_dataset_from_x_y_arrays(train_size, kwargs):
     X, y = make_classification()
-    data_groups = np.random.randint(
-        low=0, high=3, size=int(train_size * len(X))
-    ).flatten()
+    data_groups = np.random.randint(low=0, high=3, size=len(X)).flatten()
     n_groups = len(np.unique(data_groups))
     dataset = GroupedDataset.from_arrays(
         X, y, data_groups=data_groups, train_size=train_size, **kwargs
@@ -82,8 +85,16 @@ def test_creating_grouped_dataset_from_x_y_arrays(train_size, kwargs):
     for k, v in kwargs.items():
         assert getattr(dataset, k) == v
 
+
+def test_creating_grouped_dataset_from_x_y_arrays_failure(train_size):
     with pytest.raises(ValueError):
-        GroupedDataset.from_arrays(X, y, data_groups=data_groups[len(X) // 2 :])
+        X, y = make_classification()
+        # The length of data groups should be equal to that of X and y
+        data_groups_length = np.random.randint(low=0, high=len(X) - 1)
+        data_groups = np.random.randint(
+            low=0, high=3, size=data_groups_length
+        ).flatten()
+        GroupedDataset.from_arrays(X, y, data_groups=data_groups)
 
 
 def test_grouped_dataset_results():


### PR DESCRIPTION
### Description

This PR closes #324 

### Changes

- Properly split the passed `data_groups` in the `from_array()` and `from_sklearn()` methods of the `GroupedDataset` class.
- Fixes tests to reflect this change.

### Checklist

- [X] Wrote Unit tests (if necessary)
- [x] Updated Documentation (if necessary)
- [x] Updated Changelog
- [ ] If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`
