### PR TITLE
Fix publish CI pipeline

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,6 +2,8 @@ name: Publish Python Package to PyPI
 
 on:
   push:
+    branches:
+    - "**"
     tags:
     - "v*"
   workflow_dispatch:
@@ -52,7 +54,7 @@ jobs:
           echo "Should be on Master branch instead"
           exit -1
       - name: Fail if running locally
-        if: ${{ !github.event.act }} # skip during local actions testing
+        if: ${{ env.ACT }} # skip during local actions testing
         run: |
           echo "Running action locally. Failing"
           exit -1

--- a/build_scripts/release-version.sh
+++ b/build_scripts/release-version.sh
@@ -239,7 +239,7 @@ echo "🔨 Merging release branch into master"
 git checkout master
 git pull --ff-only "$REMOTE" master
 git merge --no-ff -X theirs "$RELEASE_BRANCH"
-git tag -a "$RELEASE_TAG" -m"Release $RELEASE_VERSION"
+git tag -a "$RELEASE_TAG" -m "Release $RELEASE_VERSION"
 git push --follow-tags "$REMOTE" master
 
 echo "🏷️ Bumping to next patch version"


### PR DESCRIPTION
### Description

This PR is the second attempt at fixing the publish CI pipeline. 

It wasn't triggering automatically so after doing some research I added a branches filter to the trigger.

I also fixed the check for when we're using [act](https://github.com/nektos/act) to run the pipeline locally.

### Changes

- Added branches filter to publish CI pipeline.
- Used `env.ACT` instead of `github.event.act` as variable to fail in case we're running the CI pipeline locally.

### Checklist

- [ ] Wrote Unit tests (if necessary)
- [ ] Updated Documentation (if necessary)
- [ ] Updated Changelog
- [ ] If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`
