### PR TITLE
Fix bug in adding valuation results with overlapping indices and different lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix adding valuation results with overlapping indices and different lengths
+  [PR #370](https://github.com/appliedAI-Initiative/pyDVL/pull/370)
 - Major changes to IF interface and functionality
   [PR #278](https://github.com/appliedAI-Initiative/pyDVL/pull/278)
 

--- a/notebooks/influence_imagenet.ipynb
+++ b/notebooks/influence_imagenet.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "However, in the [final part of the notebook](#detecting-corrupted-data) we will see that influence functions are an effective tool for finding anomalous or corrupted data points.\n",
     "\n",
-    "We conclude with an [appendix](#theory-of-influence-functions-for-neural-networks) with some basic theoretical concepts used."
+    "We conclude with an [appendix](#Theory-of-influence-functions-for-neural-networks) with some basic theoretical concepts used."
    ]
   },
   {
@@ -343,7 +343,7 @@
     "\n",
     "Let's now calculate influences! The main method is `:func:~pydvl.influence.general.compute_influences`, which takes a trained `nn.Model`, the training loss, some input dataset with labels (which typically is the training data, or a subset of it) and some test data.\n",
     "\n",
-    "Other important parameters are the Hessian regularization term, which should be chosen as small as possible for the computation to converge (further details on why this is important can be found in the [Appendix](#appendix)).\n",
+    "Other important parameters are the Hessian regularization term, which should be chosen as small as possible for the computation to converge (further details on why this is important can be found in the [Appendix](#Theory-of-influence-functions-for-neural-networks)).\n",
     "\n",
     "Since Resnet18 is quite big, we pick conjugate gradient (`cg`) as the method for inversion of the Hessian. A naive computation would require a lot of memory. Finally, the influence type will be `up`. The other option, `perturbation`, is beyond the scope of this notebook, but more info can be found in the notebook [using the Wine dataset](influence_wine.ipynb) or in the documentation for pyDVL.\n",
     "\n",

--- a/src/pydvl/value/result.py
+++ b/src/pydvl/value/result.py
@@ -553,17 +553,23 @@ class ValuationResult(
                     f"{other._names.dtype} to {self._names.dtype}"
                 )
 
-        this_names = np.empty_like(indices, dtype=object)
-        other_names = np.empty_like(indices, dtype=object)
-        this_names[this_pos] = self._names
-        other_names[other_pos] = other._names
-        both = np.where(this_pos == other_pos)
+        both_pos = np.intersect1d(this_pos, other_pos)
+
+        if len(both_pos) > 0:
+            this_names = np.empty_like(indices, dtype=object)
+            other_names = np.empty_like(indices, dtype=object)
+            this_names[this_pos] = self._names
+            other_names[other_pos] = other._names
+
+            this_shared_names = np.take(this_names, both_pos)
+            other_shared_names = np.take(other_names, both_pos)
+
+            if np.any(this_shared_names != other_shared_names):
+                raise ValueError(f"Mismatching names in ValuationResults")
+
         names = np.empty_like(indices, dtype=self._names.dtype)
         names[this_pos] = self._names
         names[other_pos] = other._names
-
-        if np.any(other_names[both] != this_names[both]):
-            raise ValueError(f"Mismatching names in ValuationResults")
 
         return ValuationResult(
             algorithm=self.algorithm or other.algorithm or "",

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -326,6 +326,18 @@ def test_adding_random():
             ["a", "b", "c"],
             [0, 2, 3],
         ),
+        # Overlapping indices with different lengths, change order
+        (
+            [1, 2],
+            ["b", "c"],
+            [3, 4],
+            [0, 1, 2],
+            ["a", "b", "c"],
+            [0, 1, 2],
+            [0, 1, 2],
+            ["a", "b", "c"],
+            [0, 2, 3],
+        ),
     ],
 )
 def test_adding_different_indices(


### PR DESCRIPTION
### Description

This PR closes #369 

### Changes

- Add one more test case to `test_adding_different_indices`.
- Fix bug in the `__add__` method of `ValuationResult`.
- Fix link to appendix in influence imagenet notebook.

### Checklist

- [X] Wrote Unit tests (if necessary)
- [ ] Updated Documentation (if necessary)
- [X] Updated Changelog
- [ ] If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`
