### PR TITLE
Fix failure to install dev requirements with python 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - **Breaking Changes** Add new joblib backend and set it as default
   instead of the ray backend. Simplify the MapReduceJob class.
   [PR #355](https://github.com/appliedAI-Initiative/pyDVL/pull/355)
+- **Bug fix** Fix installation of dev requirements for Python3.10
+  [PR #382](https://github.com/appliedAI-Initiative/pyDVL/pull/382)
 
 ## 0.6.1 - 🏗 Bug fixes and small improvement
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ bump2version
 pre-commit==3.1.1
 pytest==7.2.2
 pytest-cov
-pytest-docker==0.12.0
+pytest-docker==2.0.0
 pytest-mock
 pytest-timeout
 ray[default] >= 0.8

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,11 +77,6 @@ def pytorch_seed(seed):
 
 
 @pytest.fixture(scope="session")
-def docker_compose_command():
-    return "docker compose"
-
-
-@pytest.fixture(scope="session")
 def do_not_start_memcache(request):
     return request.config.getoption("--do-not-start-memcache")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,7 @@ def do_not_start_memcache(request):
 
 @pytest.fixture(scope="session")
 def docker_services(
+    docker_compose_command,
     docker_compose_file,
     docker_compose_project_name,
     docker_setup,
@@ -97,6 +98,7 @@ def docker_services(
         yield
     else:
         with get_docker_services(
+            docker_compose_command,
             docker_compose_file,
             docker_compose_project_name,
             docker_setup,

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     pytest-lazy-fixture
     pytest-timeout
     pytest-mock
-    pytest-docker==0.12.0
+    pytest-docker==2.0.0
     -r requirements.txt
 setenv =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxinidir}/.coverage.{envname}}


### PR DESCRIPTION
### Description

This PR closes #381 

### Changes

- Bumps pytest-docker to 2.0.0
- Removes `docker_compose_command` fixture

### Checklist

- [ ] Wrote Unit tests (if necessary)
- [ ] Updated Documentation (if necessary)
- [ ] Updated Changelog
- [ ] If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`
