### PR TITLE
Decouple ray.init from ParallelConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   [PR #355](https://github.com/appliedAI-Initiative/pyDVL/pull/355)
 - **Bug fix** Fix installation of dev requirements for Python3.10
   [PR #382](https://github.com/appliedAI-Initiative/pyDVL/pull/382)
+- Decouple ray.init from ParallelConfig 
+  [PR #373](https://github.com/appliedAI-Initiative/pyDVL/pull/383)
 
 ## 0.6.1 - 🏗 Bug fixes and small improvement
 

--- a/src/pydvl/utils/parallel/backend.py
+++ b/src/pydvl/utils/parallel/backend.py
@@ -106,8 +106,8 @@ class JoblibParallelBackend(BaseParallelBackend, backend_name="joblib"):
 
     def __init__(self, config: ParallelConfig):
         self.config = {
-            "n_jobs": config.n_cpus_local,
             "logging_level": config.logging_level,
+            "n_jobs": config.n_cpus_local,
         }
 
     def get(
@@ -158,11 +158,9 @@ class RayParallelBackend(BaseParallelBackend, backend_name="ray"):
     """
 
     def __init__(self, config: ParallelConfig):
-        self.config = {"logging_level": config.logging_level}
-        if config.address is None:
+        self.config = {"address": config.address, "logging_level": config.logging_level}
+        if self.config["address"] is None:
             self.config["num_cpus"] = config.n_cpus_local
-        else:
-            self.config["address"] = config.address
         if not ray.is_initialized():
             ray.init(**self.config)
         # Register ray joblib backend
@@ -232,6 +230,13 @@ def init_parallel_backend(
         with cluster address, number of cpus, etc.
 
     :Example:
+
+    >>> from pydvl.utils.parallel.backend import init_parallel_backend
+    >>> from pydvl.utils.config import ParallelConfig
+    >>> config = ParallelConfig()
+    >>> parallel_backend = init_parallel_backend(config)
+    >>> parallel_backend
+    <JoblibParallelBackend: {'logging_level': 30, 'n_jobs': None}>
 
     >>> from pydvl.utils.parallel.backend import init_parallel_backend
     >>> from pydvl.utils.config import ParallelConfig

--- a/src/pydvl/utils/parallel/backend.py
+++ b/src/pydvl/utils/parallel/backend.py
@@ -105,14 +105,10 @@ class JoblibParallelBackend(BaseParallelBackend, backend_name="joblib"):
     """
 
     def __init__(self, config: ParallelConfig):
-        config_dict = asdict(config)
-        config_dict.pop("backend")
-        n_cpus_local = config_dict.pop("n_cpus_local")
-        config_dict["n_jobs"] = n_cpus_local
-        self.config = config_dict
-        # In joblib the levels are reversed.
-        # 0 means no logging and 50 means log everything to stdout
-        verbose = 50 - config_dict["logging_level"]
+        self.config = {
+            "n_jobs": config.n_cpus_local,
+            "logging_level": config.logging_level,
+        }
 
     def get(
         self,
@@ -162,12 +158,11 @@ class RayParallelBackend(BaseParallelBackend, backend_name="ray"):
     """
 
     def __init__(self, config: ParallelConfig):
-        config_dict = asdict(config)
-        config_dict.pop("backend")
-        n_cpus_local = config_dict.pop("n_cpus_local")
-        if config_dict.get("address", None) is None:
-            config_dict["num_cpus"] = n_cpus_local
-        self.config = config_dict
+        self.config = {"logging_level": config.logging_level}
+        if config.address is None:
+            self.config["num_cpus"] = config.n_cpus_local
+        else:
+            self.config["address"] = config.address
         if not ray.is_initialized():
             ray.init(**self.config)
         # Register ray joblib backend

--- a/src/pydvl/utils/parallel/map_reduce.py
+++ b/src/pydvl/utils/parallel/map_reduce.py
@@ -103,7 +103,10 @@ class MapReduceJob(Generic[T, R]):
             backend = "loky"
         else:
             backend = self.config.backend
-        with Parallel(backend=backend, n_jobs=self.n_jobs) as parallel:
+        # In joblib the levels are reversed.
+        # 0 means no logging and 50 means log everything to stdout
+        verbose = 50 - self.config.logging_level
+        with Parallel(backend=backend, n_jobs=self.n_jobs, verbose=verbose) as parallel:
             chunks = self._chunkify(self.inputs_, n_chunks=self.n_jobs)
             map_results: List[R] = parallel(
                 delayed(self._map_func)(next_chunk, job_id=j, **self.map_kwargs)


### PR DESCRIPTION
### Description

This PR closes #373 

### Changes

- Explicitly pick values from ParallelConfig when initializing a parallel backend.

### Checklist

- [ ] Wrote Unit tests (if necessary)
- [ ] Updated Documentation (if necessary)
- [x] Updated Changelog
- [ ] If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`
