### PR TITLE
Make ray an optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Made ray an optional dependency, relying on joblib as default parallel backend
+  [PR #408](https://github.com/appliedAI-Initiative/pyDVL/pull/408)
 - Fixes to parallel computation of generic semi-values: properly handle all
   samplers and stopping criteria, irrespective of parallel backend
   [PR #372](https://github.com/appliedAI-Initiative/pyDVL/pull/372)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -177,7 +177,7 @@ def lineno_from_object_name(source_file, object_name):
 
 # this is useful for keeping the docs build environment small. Add heavy requirements here
 # and all other requirements to docs/requirements.txt
-autodoc_mock_imports = []
+autodoc_mock_imports = ["ray"]
 
 autodoc_default_options = {
     "exclude-members": "log",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ pandas>=1.3
 scikit-learn
 scipy>=1.7.0
 cvxpy>=1.3.0
-ray>=0.8
 joblib
 pymemcache
 cloudpickle

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,11 @@ setup(
     ],
     setup_requires=["wheel"],
     tests_require=["pytest"],
-    extras_require={"influence": ["torch>=2.0.0"], "cupy": ["cupy-cuda11x>=12.1.0"]},
+    extras_require={
+        "cupy": ["cupy-cuda11x>=12.1.0"],
+        "influence": ["torch>=2.0.0"],
+        "ray": ["ray>=0.8"],
+    },
     author="appliedAI Institute gGmbH",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/pydvl/utils/parallel/__init__.py
+++ b/src/pydvl/utils/parallel/__init__.py
@@ -1,3 +1,7 @@
 from .backend import *
+from .backends import *
 from .futures import *
 from .map_reduce import *
+
+if len(BaseParallelBackend.BACKENDS) == 0:
+    raise ImportError("No parallel backend found. Please install ray or joblib.")

--- a/src/pydvl/utils/parallel/backend.py
+++ b/src/pydvl/utils/parallel/backend.py
@@ -19,8 +19,6 @@ __all__ = [
 ]
 
 
-T = TypeVar("T")
-
 log = logging.getLogger(__name__)
 
 

--- a/src/pydvl/utils/parallel/backend.py
+++ b/src/pydvl/utils/parallel/backend.py
@@ -5,19 +5,18 @@ import os
 from abc import abstractmethod
 from concurrent.futures import Executor
 from enum import Flag, auto
-from typing import Any, Callable, Iterable, Type, TypeVar, cast
-
-import joblib
-import ray
-from joblib import delayed
-from joblib.externals.loky import get_reusable_executor
-from ray import ObjectRef
-from ray.util.joblib import register_ray
+from typing import Any, Callable, Type, TypeVar
 
 from ..config import ParallelConfig
 from ..types import NoPublicConstructor
 
-__all__ = ["init_parallel_backend", "effective_n_jobs", "available_cpus"]
+__all__ = [
+    "init_parallel_backend",
+    "effective_n_jobs",
+    "available_cpus",
+    "BaseParallelBackend",
+    "CancellationPolicy",
+]
 
 
 T = TypeVar("T")
@@ -92,135 +91,6 @@ class BaseParallelBackend(metaclass=NoPublicConstructor):
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {self.config}>"
-
-
-class JoblibParallelBackend(BaseParallelBackend, backend_name="joblib"):
-    """Class used to wrap joblib to make it transparent to algorithms.
-
-    It shouldn't be initialized directly. You should instead call
-    :func:`~pydvl.utils.parallel.backend.init_parallel_backend`.
-
-    :param config: instance of :class:`~pydvl.utils.config.ParallelConfig` with
-        cluster address, number of cpus, etc.
-    """
-
-    def __init__(self, config: ParallelConfig):
-        self.config = {
-            "logging_level": config.logging_level,
-            "n_jobs": config.n_cpus_local,
-        }
-
-    @classmethod
-    def executor(
-        cls,
-        max_workers: int | None = None,
-        config: ParallelConfig = ParallelConfig(),
-        cancel_futures: CancellationPolicy = CancellationPolicy.NONE,
-    ) -> Executor:
-        if cancel_futures not in (CancellationPolicy.NONE, False):
-            log.warning(
-                "Cancellation of futures is not supported by the joblib backend"
-            )
-        return cast(Executor, get_reusable_executor(max_workers=max_workers))
-
-    def get(self, v: T, *args, **kwargs) -> T:
-        return v
-
-    def put(self, v: T, *args, **kwargs) -> T:
-        return v
-
-    def wrap(self, fun: Callable, **kwargs) -> Callable:
-        """Wraps a function as a joblib delayed.
-
-        :param fun: the function to wrap
-
-        :return: The delayed function.
-        """
-        return delayed(fun)  # type: ignore
-
-    def wait(self, v: list[T], *args, **kwargs) -> tuple[list[T], list[T]]:
-        return v, []
-
-    def _effective_n_jobs(self, n_jobs: int) -> int:
-        if self.config["n_jobs"] is None:
-            maximum_n_jobs = joblib.effective_n_jobs()
-        else:
-            maximum_n_jobs = self.config["n_jobs"]
-        eff_n_jobs: int = min(joblib.effective_n_jobs(n_jobs), maximum_n_jobs)
-        return eff_n_jobs
-
-
-class RayParallelBackend(BaseParallelBackend, backend_name="ray"):
-    """Class used to wrap ray to make it transparent to algorithms.
-
-    It shouldn't be initialized directly. You should instead call
-    :func:`~pydvl.utils.parallel.backend.init_parallel_backend`.
-
-    :param config: instance of :class:`~pydvl.utils.config.ParallelConfig` with
-        cluster address, number of cpus, etc.
-    """
-
-    def __init__(self, config: ParallelConfig):
-        self.config = {"address": config.address, "logging_level": config.logging_level}
-        if self.config["address"] is None:
-            self.config["num_cpus"] = config.n_cpus_local
-        if not ray.is_initialized():
-            ray.init(**self.config)
-        # Register ray joblib backend
-        register_ray()
-
-    @classmethod
-    def executor(
-        cls,
-        max_workers: int | None = None,
-        config: ParallelConfig = ParallelConfig(),
-        cancel_futures: CancellationPolicy = CancellationPolicy.PENDING,
-    ) -> Executor:
-        from pydvl.utils.parallel.futures.ray import RayExecutor
-
-        return RayExecutor(max_workers, config=config, cancel_futures=cancel_futures)  # type: ignore
-
-    def get(self, v: ObjectRef | Iterable[ObjectRef] | T, *args, **kwargs) -> T | Any:
-        timeout: float | None = kwargs.get("timeout", None)
-        if isinstance(v, ObjectRef):
-            return ray.get(v, timeout=timeout)
-        elif isinstance(v, Iterable):
-            return [self.get(x, timeout=timeout) for x in v]
-        else:
-            return v
-
-    def put(self, v: T, *args, **kwargs) -> ObjectRef[T] | T:
-        try:
-            return ray.put(v, **kwargs)  # type: ignore
-        except TypeError:
-            return v  # type: ignore
-
-    def wrap(self, fun: Callable, **kwargs) -> Callable:
-        """Wraps a function as a ray remote.
-
-        :param fun: the function to wrap
-        :param kwargs: keyword arguments to pass to @ray.remote
-
-        :return: The `.remote` method of the ray `RemoteFunction`.
-        """
-        if len(kwargs) > 0:
-            return ray.remote(**kwargs)(fun).remote  # type: ignore
-        return ray.remote(fun).remote  # type: ignore
-
-    def wait(
-        self, v: list[ObjectRef], *args, **kwargs
-    ) -> tuple[list[ObjectRef], list[ObjectRef]]:
-        num_returns: int = kwargs.get("num_returns", 1)
-        timeout: float | None = kwargs.get("timeout", None)
-        return ray.wait(v, num_returns=num_returns, timeout=timeout)  # type: ignore
-
-    def _effective_n_jobs(self, n_jobs: int) -> int:
-        ray_cpus = int(ray._private.state.cluster_resources()["CPU"])  # type: ignore
-        if n_jobs < 0:
-            eff_n_jobs = ray_cpus
-        else:
-            eff_n_jobs = min(n_jobs, ray_cpus)
-        return eff_n_jobs
 
 
 def init_parallel_backend(config: ParallelConfig) -> BaseParallelBackend:

--- a/src/pydvl/utils/parallel/backend.py
+++ b/src/pydvl/utils/parallel/backend.py
@@ -99,19 +99,22 @@ def init_parallel_backend(config: ParallelConfig) -> BaseParallelBackend:
 
     :Example:
 
-    >>> from pydvl.utils.parallel.backend import init_parallel_backend
-    >>> from pydvl.utils.config import ParallelConfig
-    >>> config = ParallelConfig()
-    >>> parallel_backend = init_parallel_backend(config)
-    >>> parallel_backend
-    <JoblibParallelBackend: {'logging_level': 30, 'n_jobs': None}>
+    ``` python
+    config = ParallelConfig()
+    parallel_backend = init_parallel_backend(config)
+    ```
 
-    >>> from pydvl.utils.parallel.backend import init_parallel_backend
-    >>> from pydvl.utils.config import ParallelConfig
-    >>> config = ParallelConfig(backend="ray")
-    >>> parallel_backend = init_parallel_backend(config)
-    >>> parallel_backend
-    <RayParallelBackend: {'address': None, 'logging_level': 30, 'num_cpus': None}>
+    Creates a parallel backend instance with the default configuration, which
+    is a local joblib backend.
+
+    To create a parallel backend instance with a different backend, e.g. ray,
+    you can pass the backend name as a string to the constructor of
+    :class:`~pydvl.utils.config.ParallelConfig`:
+
+    .. code-block:: python
+
+       config = ParallelConfig(backend="ray")
+       parallel_backend = init_parallel_backend(config)
 
     """
     try:

--- a/src/pydvl/utils/parallel/backends/__init__.py
+++ b/src/pydvl/utils/parallel/backends/__init__.py
@@ -1,0 +1,9 @@
+try:
+    from .joblib import *
+except ImportError:
+    pass
+
+try:
+    from .ray import *
+except ImportError:
+    pass

--- a/src/pydvl/utils/parallel/backends/__init__.py
+++ b/src/pydvl/utils/parallel/backends/__init__.py
@@ -1,7 +1,4 @@
-try:
-    from .joblib import *
-except ImportError:
-    pass
+from .joblib import *
 
 try:
     from .ray import *

--- a/src/pydvl/utils/parallel/backends/joblib.py
+++ b/src/pydvl/utils/parallel/backends/joblib.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 from concurrent.futures import Executor
-from typing import Callable, cast
+from typing import Callable, TypeVar, cast
 
 import joblib
 from joblib import delayed
 from joblib.externals.loky import get_reusable_executor
 
 from pydvl.utils import ParallelConfig
-from pydvl.utils.parallel.backend import BaseParallelBackend, CancellationPolicy, T, log
+from pydvl.utils.parallel.backend import BaseParallelBackend, CancellationPolicy, log
+
+__all__ = ["JoblibParallelBackend"]
+
+T = TypeVar("T")
 
 
 class JoblibParallelBackend(BaseParallelBackend, backend_name="joblib"):

--- a/src/pydvl/utils/parallel/backends/joblib.py
+++ b/src/pydvl/utils/parallel/backends/joblib.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from concurrent.futures import Executor
+from typing import Callable, cast
+
+import joblib
+from joblib import delayed
+from joblib.externals.loky import get_reusable_executor
+
+from pydvl.utils import ParallelConfig
+from pydvl.utils.parallel.backend import BaseParallelBackend, CancellationPolicy, T, log
+
+
+class JoblibParallelBackend(BaseParallelBackend, backend_name="joblib"):
+    """Class used to wrap joblib to make it transparent to algorithms.
+
+    It shouldn't be initialized directly. You should instead call
+    :func:`~pydvl.utils.parallel.backend.init_parallel_backend`.
+
+    :param config: instance of :class:`~pydvl.utils.config.ParallelConfig` with
+        cluster address, number of cpus, etc.
+    """
+
+    def __init__(self, config: ParallelConfig):
+        self.config = {
+            "logging_level": config.logging_level,
+            "n_jobs": config.n_cpus_local,
+        }
+
+    @classmethod
+    def executor(
+        cls,
+        max_workers: int | None = None,
+        config: ParallelConfig = ParallelConfig(),
+        cancel_futures: CancellationPolicy = CancellationPolicy.NONE,
+    ) -> Executor:
+        if cancel_futures not in (CancellationPolicy.NONE, False):
+            log.warning(
+                "Cancellation of futures is not supported by the joblib backend"
+            )
+        return cast(Executor, get_reusable_executor(max_workers=max_workers))
+
+    def get(self, v: T, *args, **kwargs) -> T:
+        return v
+
+    def put(self, v: T, *args, **kwargs) -> T:
+        return v
+
+    def wrap(self, fun: Callable, **kwargs) -> Callable:
+        """Wraps a function as a joblib delayed.
+
+        :param fun: the function to wrap
+
+        :return: The delayed function.
+        """
+        return delayed(fun)  # type: ignore
+
+    def wait(self, v: list[T], *args, **kwargs) -> tuple[list[T], list[T]]:
+        return v, []
+
+    def _effective_n_jobs(self, n_jobs: int) -> int:
+        if self.config["n_jobs"] is None:
+            maximum_n_jobs = joblib.effective_n_jobs()
+        else:
+            maximum_n_jobs = self.config["n_jobs"]
+        eff_n_jobs: int = min(joblib.effective_n_jobs(n_jobs), maximum_n_jobs)
+        return eff_n_jobs

--- a/src/pydvl/utils/parallel/backends/ray.py
+++ b/src/pydvl/utils/parallel/backends/ray.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 from concurrent.futures import Executor
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, TypeVar
 
 import ray
 from ray import ObjectRef
 from ray.util.joblib import register_ray
 
 from pydvl.utils import ParallelConfig
-from pydvl.utils.parallel.backend import BaseParallelBackend, CancellationPolicy, T
+from pydvl.utils.parallel.backend import BaseParallelBackend, CancellationPolicy
+
+__all__ = ["RayParallelBackend"]
+
+
+T = TypeVar("T")
 
 
 class RayParallelBackend(BaseParallelBackend, backend_name="ray"):

--- a/src/pydvl/utils/parallel/backends/ray.py
+++ b/src/pydvl/utils/parallel/backends/ray.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from concurrent.futures import Executor
+from typing import Any, Callable, Iterable
+
+import ray
+from ray import ObjectRef
+from ray.util.joblib import register_ray
+
+from pydvl.utils import ParallelConfig
+from pydvl.utils.parallel.backend import BaseParallelBackend, CancellationPolicy, T
+
+
+class RayParallelBackend(BaseParallelBackend, backend_name="ray"):
+    """Class used to wrap ray to make it transparent to algorithms.
+
+    It shouldn't be initialized directly. You should instead call
+    :func:`~pydvl.utils.parallel.backend.init_parallel_backend`.
+
+    :param config: instance of :class:`~pydvl.utils.config.ParallelConfig` with
+        cluster address, number of cpus, etc.
+    """
+
+    def __init__(self, config: ParallelConfig):
+        self.config = {"address": config.address, "logging_level": config.logging_level}
+        if self.config["address"] is None:
+            self.config["num_cpus"] = config.n_cpus_local
+        if not ray.is_initialized():
+            ray.init(**self.config)
+        # Register ray joblib backend
+        register_ray()
+
+    @classmethod
+    def executor(
+        cls,
+        max_workers: int | None = None,
+        config: ParallelConfig = ParallelConfig(),
+        cancel_futures: CancellationPolicy = CancellationPolicy.PENDING,
+    ) -> Executor:
+        from pydvl.utils.parallel.futures.ray import RayExecutor
+
+        return RayExecutor(max_workers, config=config, cancel_futures=cancel_futures)  # type: ignore
+
+    def get(self, v: ObjectRef | Iterable[ObjectRef] | T, *args, **kwargs) -> T | Any:
+        timeout: float | None = kwargs.get("timeout", None)
+        if isinstance(v, ObjectRef):
+            return ray.get(v, timeout=timeout)
+        elif isinstance(v, Iterable):
+            return [self.get(x, timeout=timeout) for x in v]
+        else:
+            return v
+
+    def put(self, v: T, *args, **kwargs) -> ObjectRef[T] | T:
+        try:
+            return ray.put(v, **kwargs)  # type: ignore
+        except TypeError:
+            return v  # type: ignore
+
+    def wrap(self, fun: Callable, **kwargs) -> Callable:
+        """Wraps a function as a ray remote.
+
+        :param fun: the function to wrap
+        :param kwargs: keyword arguments to pass to @ray.remote
+
+        :return: The `.remote` method of the ray `RemoteFunction`.
+        """
+        if len(kwargs) > 0:
+            return ray.remote(**kwargs)(fun).remote  # type: ignore
+        return ray.remote(fun).remote  # type: ignore
+
+    def wait(
+        self, v: list[ObjectRef], *args, **kwargs
+    ) -> tuple[list[ObjectRef], list[ObjectRef]]:
+        num_returns: int = kwargs.get("num_returns", 1)
+        timeout: float | None = kwargs.get("timeout", None)
+        return ray.wait(v, num_returns=num_returns, timeout=timeout)  # type: ignore
+
+    def _effective_n_jobs(self, n_jobs: int) -> int:
+        ray_cpus = int(ray._private.state.cluster_resources()["CPU"])  # type: ignore
+        if n_jobs < 0:
+            eff_n_jobs = ray_cpus
+        else:
+            eff_n_jobs = min(n_jobs, ray_cpus)
+        return eff_n_jobs

--- a/src/pydvl/utils/parallel/futures/__init__.py
+++ b/src/pydvl/utils/parallel/futures/__init__.py
@@ -31,28 +31,24 @@ def init_executor(
         e.g. ``cancel_futures`` for executors that support it, like
         :class:`~pydvl.utils.parallel.futures.ray.RayExecutor`.
 
-    :Example:
+    :Examples:
 
-    >>> from pydvl.utils.parallel.futures import init_executor
-    >>> from pydvl.utils.config import ParallelConfig
-    >>> config = ParallelConfig(backend="ray")
-    >>> with init_executor(max_workers=3, config=config) as executor:
-    ...     pass
+    .. code-block:: python
 
-    >>> from pydvl.utils.parallel.futures import init_executor
-    >>> with init_executor() as executor:
-    ...     future = executor.submit(lambda x: x + 1, 1)
-    ...     result = future.result()
-    ...
-    >>> print(result)
-    2
+       from pydvl.utils.parallel.futures import init_executor
+       from pydvl.utils.config import ParallelConfig
+       config = ParallelConfig(backend="ray")
+       with init_executor(max_workers=1, config=config) as executor:
+           future = executor.submit(lambda x: x + 1, 1)
+           result = future.result()
+       assert result == 2
 
-    >>> from pydvl.utils.parallel.futures import init_executor
-    >>> with init_executor() as executor:
-    ...     results = list(executor.map(lambda x: x + 1, range(5)))
-    ...
-    >>> print(results)
-    [1, 2, 3, 4, 5]
+    .. code-block:: python
+
+       from pydvl.utils.parallel.futures import init_executor
+       with init_executor() as executor:
+           results = list(executor.map(lambda x: x + 1, range(5)))
+       assert results == [1, 2, 3, 4, 5]
 
     """
     try:

--- a/src/pydvl/utils/parallel/futures/__init__.py
+++ b/src/pydvl/utils/parallel/futures/__init__.py
@@ -5,7 +5,11 @@ from typing import Generator, Optional
 
 from pydvl.utils.config import ParallelConfig
 from pydvl.utils.parallel.backend import BaseParallelBackend
-from pydvl.utils.parallel.futures.ray import RayExecutor
+
+try:
+    from pydvl.utils.parallel.futures.ray import RayExecutor
+except ImportError:
+    pass
 
 __all__ = ["init_executor"]
 

--- a/src/pydvl/utils/parallel/futures/ray.py
+++ b/src/pydvl/utils/parallel/futures/ray.py
@@ -15,7 +15,7 @@ from pydvl.utils import ParallelConfig
 
 __all__ = ["RayExecutor"]
 
-from pydvl.utils.parallel.backend import CancellationPolicy
+from pydvl.utils.parallel import CancellationPolicy
 
 T = TypeVar("T")
 

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -48,8 +48,7 @@ from tqdm import tqdm
 from pydvl.utils import effective_n_jobs, init_executor, init_parallel_backend
 from pydvl.utils.config import ParallelConfig
 from pydvl.utils.numeric import random_powerset
-from pydvl.utils.parallel import MapReduceJob
-from pydvl.utils.parallel.futures.ray import CancellationPolicy
+from pydvl.utils.parallel import CancellationPolicy, MapReduceJob
 from pydvl.utils.utility import Utility
 from pydvl.value.result import ValuationResult
 from pydvl.value.shapley.truncated import NoTruncation, TruncationPolicy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Optional, Sequence, Tuple, Type
 
 import numpy as np
 import pytest
-import ray
 from pymemcache.client import Client
 from sklearn import datasets
 from sklearn.utils import Bunch
@@ -19,12 +18,6 @@ if TYPE_CHECKING:
     from _pytest.terminal import TerminalReporter
 
 EXCEPTIONS_TYPE = Optional[Sequence[Type[BaseException]]]
-
-
-@pytest.fixture(scope="session", autouse=True)
-def ray_shutdown():
-    yield
-    ray.shutdown()
 
 
 def is_memcache_responsive(hostname, port):

--- a/tests/utils/conftest.py
+++ b/tests/utils/conftest.py
@@ -1,6 +1,4 @@
 import pytest
-import ray
-from ray.cluster_utils import Cluster
 
 from pydvl.utils.config import ParallelConfig
 
@@ -10,9 +8,18 @@ def parallel_config(request, num_workers):
     if request.param == "joblib":
         yield ParallelConfig(backend="joblib", n_cpus_local=num_workers)
     elif request.param == "ray-local":
+        try:
+            import ray
+        except ImportError:
+            pytest.skip("Ray not installed.")
         yield ParallelConfig(backend="ray", n_cpus_local=num_workers)
         ray.shutdown()
     elif request.param == "ray-external":
+        try:
+            import ray
+            from ray.cluster_utils import Cluster
+        except ImportError:
+            pytest.skip("Ray not installed.")
         # Starts a head-node for the cluster.
         cluster = Cluster(
             initialize_head=True,

--- a/tests/utils/test_parallel.py
+++ b/tests/utils/test_parallel.py
@@ -206,7 +206,7 @@ def test_future_cancellation(parallel_config):
     if parallel_config.backend != "ray":
         pytest.skip("Currently this test only works with Ray")
 
-    from pydvl.utils.parallel.futures.ray import CancellationPolicy
+    from pydvl.utils.parallel import CancellationPolicy
 
     with init_executor(
         config=parallel_config, cancel_futures=CancellationPolicy.NONE

--- a/tests/value/conftest.py
+++ b/tests/value/conftest.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
-import ray
 from numpy.typing import NDArray
-from ray.cluster_utils import Cluster
 from sklearn.linear_model import LinearRegression
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import PolynomialFeatures


### PR DESCRIPTION
<!--
Thanks for making a contribution! 
Please make sure you have read the contributing guide: 
https://github.com/appliedAI-Initiative/pyDVL/blob/develop/CONTRIBUTING.md
-->

### Description

This PR closes #380 #367 .

### Changes
Because we are already using a sub-class registry, there was little to do:

- Moved ParallelBackends into separate modules
- Guard imports
- Adapt the tests to skip if ray is not available. Not very elegant, but the alternative was to change the fixture `parallel_backend` and that would have meant a lot more changes. Ideas? (I'd just leave it as is tbh)
- **Documentation is missing**, waiting until we have #261 to avoid silly conflicts


### Checklist

- [x] Wrote Unit tests (if necessary)
- [ ] Updated Documentation (if necessary)
- [x] Updated Changelog
- [x] ~If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`~
