### PR TITLE
Add binder links to rendered notebooks

### DIFF
--- a/build_scripts/modify_binder_link.py
+++ b/build_scripts/modify_binder_link.py
@@ -3,6 +3,8 @@ This mkdocs hook replaces the binder link in the rendered notebooks
 with links to the actual notebooks in the repository.
 This is needed because for the docs we create symlinks to the notebooks
 inside the docs directory.
+This is heavily inspired from:
+https://github.com/greenape/mknotebooks/blob/master/mknotebooks/plugin.py#L322
 """
 
 import logging
@@ -20,7 +22,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger("mkdocs")
 
 BINDER_BASE_URL = "https://mybinder.org/v2"
-BINDER_URL_PATTERN = re.compile(r"\(" + re.escape(BINDER_BASE_URL) + r".*\)")
+BINDER_LOGO_WITH_CAPTION = "[![Binder](https://mybinder.org/badge_logo.svg)]"
+BINDER_LOGO_WITHOUT_CAPTION = "[![](https://mybinder.org/badge_logo.svg)]"
+BINDER_LINK_PATTERN = re.compile(
+    re.escape(BINDER_LOGO_WITH_CAPTION) + r"\(" + re.escape(BINDER_BASE_URL) + r".*\)"
+)
 
 branch_name: Optional[str] = None
 
@@ -51,7 +57,9 @@ def on_page_markdown(
     notebook_filename = Path(page.file.src_path).name
     file_path = (notebooks_dir / notebook_filename).relative_to(root_dir)
     url_path = f"%2Ftree%2F{file_path}"
-    binder_url = f"({BINDER_BASE_URL}/gh/{repo_name}/{branch_name}?urlpath={url_path})"
-    logger.debug(f"New binder url: {binder_url}")
-    markdown = re.sub(BINDER_URL_PATTERN, binder_url, markdown)
+    binder_url = f"{BINDER_BASE_URL}/gh/{repo_name}/{branch_name}?urlpath={url_path}"
+    binder_link = f"{BINDER_LOGO_WITHOUT_CAPTION}({binder_url})"
+    logger.info(f"New binder url: {binder_url}")
+    logger.info(f"Using regex: {BINDER_LINK_PATTERN}")
+    markdown = re.sub(BINDER_LINK_PATTERN, binder_link, markdown)
     return markdown

--- a/build_scripts/modify_binder_link.py
+++ b/build_scripts/modify_binder_link.py
@@ -1,0 +1,57 @@
+"""
+This mkdocs hook replaces the binder link in the rendered notebooks
+with links to the actual notebooks in the repository.
+This is needed because for the docs we create symlinks to the notebooks
+inside the docs directory.
+"""
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, Optional
+
+from git import Repo
+from mkdocs.plugins import Config, event_priority
+
+if TYPE_CHECKING:
+    from mkdocs.plugins import Files, Page
+
+logger = logging.getLogger("mkdocs")
+
+BINDER_BASE_URL = "https://mybinder.org/v2"
+BINDER_URL_PATTERN = re.compile(r"\(" + re.escape(BINDER_BASE_URL) + r".*\)")
+
+branch_name: Optional[str] = None
+
+
+@event_priority(-50)
+def on_startup(command: Literal["build", "gh-deploy", "serve"], dirty: bool) -> None:
+    global branch_name
+    try:
+        branch_name = Repo().active_branch.name
+        logger.info(f"Found branch name using git: {branch_name}")
+    except TypeError:
+        branch_name = os.getenv("GITHUB_REF", "develop").split("/")[-1]
+        logger.info(f"Found branch name from environment variable: {branch_name}")
+
+
+@event_priority(-50)
+def on_page_markdown(
+    markdown: str, page: "Page", config: Config, files: "Files"
+) -> Optional[str]:
+    if "examples" not in page.url:
+        return
+    logger.info(
+        f"Replacing binder link with link to notebook in repository for notebooks in {page.url}"
+    )
+    repo_name = config["repo_name"]
+    root_dir = Path(config["docs_dir"]).parent
+    notebooks_dir = root_dir / "notebooks"
+    notebook_filename = Path(page.file.src_path).name
+    file_path = (notebooks_dir / notebook_filename).relative_to(root_dir)
+    url_path = f"%2Ftree%2F{file_path}"
+    binder_url = f"({BINDER_BASE_URL}/gh/{repo_name}/{branch_name}?urlpath={url_path})"
+    logger.debug(f"New binder url: {binder_url}")
+    markdown = re.sub(BINDER_URL_PATTERN, binder_url, markdown)
+    return markdown

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -111,11 +111,6 @@ body[data-md-color-scheme="slate"] .invertible img {
 }
 
 /* Rendered dataframe from jupyter */
-div.rendered_html {
-    width: 100% !important;
-    overflow-x: scroll;
-}
-
 table.dataframe {
     display: block;
     max-width: -moz-fit-content;

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -109,3 +109,18 @@ body[data-md-color-scheme="default"] .invertible img {
 body[data-md-color-scheme="slate"] .invertible img {
     filter: invert(100%) hue-rotate(180deg);
 }
+
+/* Rendered dataframe from jupyter */
+div.rendered_html {
+    width: 100% !important;
+    overflow-x: scroll;
+}
+
+table.dataframe {
+    display: block;
+    max-width: -moz-fit-content;
+    max-width: fit-content;
+    margin: 0 auto;
+    overflow-x: auto;
+    white-space: nowrap;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: "pyDVL"
 site_dir: "docs_build"
 site_url: "https://appliedai-initiative.github.io/pyDVL/"
+repo_name: "appliedAI-Initiative/pyDVL"
 repo_url: "https://github.com/appliedAI-Initiative/pyDVL"
 copyright: "Copyright &copy; AppliedAI Institute gGmbH"
 
@@ -11,6 +12,7 @@ watch:
 hooks:
   - build_scripts/copy_notebooks.py
   - build_scripts/copy_changelog.py
+  - build_scripts/modify_binder_link.py
 
 plugins:
   - autorefs
@@ -41,13 +43,17 @@ plugins:
       nav_file: SUMMARY.md
       implicit_index: false
       tab_length: 2
-  - mkdocs-jupyter:
-      include: ["docs/examples/*.ipynb"]
-      remove_tag_config:
+  - mknotebooks:
+      execute: false
+      enable_default_jupyter_cell_styling: false
+      tag_remove_configs:
         remove_cell_tags:
           - hide
         remove_input_tags:
           - hide-input
+      binder: true
+      binder_service_name: "gh"
+      binder_branch: "develop"
   - mkdocstrings:
       enable_inventory: true
       handlers:
@@ -151,6 +157,7 @@ markdown_extensions:
   - markdown_captions
   - md_in_html
   - neoteroi.cards
+  - codehilite
   - toc:
       permalink: True
       toc_depth: 3

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -8,10 +8,12 @@ mkdocs-bibtex
 mkdocs-gen-files
 mkdocs-git-revision-date-localized-plugin
 mkdocs-glightbox
-mkdocs-jupyter
+mknotebooks>=0.8.0
+pygments
 mkdocs-literate-nav
 mkdocs-material
 mkdocs-section-index
 mkdocs-macros-plugin
 neoteroi-mkdocs  # Needed for card grid on home page
 pypandoc_binary
+GitPython


### PR DESCRIPTION
### Description

This PR closes #405 

![image](https://github.com/appliedAI-Initiative/pyDVL/assets/27914730/dd52ba06-cebc-43c8-bda9-95e3f859ea8f)


### Changes

- Uses `mknotebooks` instead of `mkdocs-jupyter`.
- Added hook to replace binder url created by mknotebooks.

### Checklist

- [ ] Wrote Unit tests (if necessary)
- [ ] Updated Documentation (if necessary)
- [ ] Updated Changelog
- [ ] If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`
