### PR TITLE
Fix/rename semivalues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
   [PR #365](https://github.com/appliedAI-Initiative/pyDVL/pull/365)
 - **Breaking Changes**:
   - Renamed `semivalues` to `compute_generic_semivalues`
-    [PR #...]()
+    [PR #413](https://github.com/appliedAI-Initiative/pyDVL/pull/413)
   - Add new joblib backend and set it as default
     instead of the ray backend. Simplify the MapReduceJob class.
     [PR #355](https://github.com/appliedAI-Initiative/pyDVL/pull/355)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
   approximation
   [PR #365](https://github.com/appliedAI-Initiative/pyDVL/pull/365)
 - **Breaking Changes**:
+  - Renamed `semivalues` to `compute_generic_semivalues`
+    [PR #...]()
   - Add new joblib backend and set it as default
     instead of the ray backend. Simplify the MapReduceJob class.
     [PR #355](https://github.com/appliedAI-Initiative/pyDVL/pull/355)

--- a/docs/value/semi-values.md
+++ b/docs/value/semi-values.md
@@ -112,11 +112,11 @@ from pydvl.value import *
 
 data = Dataset(...)
 utility = Utility(model, data)
-values = semivalues(
-    sampler=PermutationSampler(data.indices),
-    u=utility,
-    coefficient=beta_coefficient(alpha=1, beta=16),
-    done=AbsoluteStandardError(threshold=1e-4),
+values = compute_generic_semivalues(
+  sampler=PermutationSampler(data.indices),
+  u=utility,
+  coefficient=beta_coefficient(alpha=1, beta=16),
+  done=AbsoluteStandardError(threshold=1e-4),
   )
 ```
 

--- a/src/pydvl/value/semivalues.py
+++ b/src/pydvl/value/semivalues.py
@@ -26,14 +26,17 @@ permutations of $D$. The former conform to the above definition of semi-values,
 while the latter reformulates it as:
 
 $$
-v_u(x_i) = \frac{1}{n!} \sum_{\sigma \in \Pi(n)}
-\tilde{w}( | \sigma_{:i} | )[u(\sigma_{:i} \cup \{i\}) − u(\sigma_{:i})],
+v(i) = \frac{1}{n!} \sum_{\sigma \in \Pi(n)}
+\tilde{w}( | \sigma_{:i} | )[U(\sigma_{:i} \cup \{i\}) − U(\sigma_{:i})],
 $$
 
 where $\sigma_{:i}$ denotes the set of indices in permutation sigma before the
-position where $i$ appears (see [Data valuation][computing-data-values] for details), and
-$\tilde{w}(k) = n \choose{n-1}{k} w(k)$ is the weight correction due to the
-reformulation.
+position where $i$ appears (see [Data valuation][computing-data-values] for
+details), and
+
+$$ \tilde{w} (k) = n \binom{n - 1}{k} w (k) $$
+
+is the weight correction due to the reformulation.
 
 !!! Warning
     Both [PermutationSampler][pydvl.value.sampler.PermutationSampler] and
@@ -364,6 +367,13 @@ def compute_beta_shapley_semivalues(
     remove_in="0.8.0",
 )
 class SemiValueMode(str, Enum):
+    """Enumeration of semi-value modes.
+
+    !!! warning "Deprecation notice"
+        This enum and the associated methods are deprecated and will be removed
+        in 0.8.0.
+    """
+
     Shapley = "shapley"
     BetaShapley = "beta_shapley"
     Banzhaf = "banzhaf"
@@ -381,31 +391,30 @@ def compute_semivalues(
 ) -> ValuationResult:
     """Convenience entry point for most common semi-value computations.
 
-    !!! Warning
-       This method is deprecated and will be replaced in 0.8.0 by the more
-       general implementation of
-       [compute_generic_semivalues][pydvl.value.semivalues.compute_generic_semivalues].
-       Use
-       [compute_shapley_semivalues][pydvl.value.semivalues.compute_shapley_semivalues],
-       [compute_banzhaf_semivalues][pydvl.value.semivalues.compute_banzhaf_semivalues], or
-       [compute_beta_shapley_semivalues][pydvl.value.semivalues.compute_beta_shapley_semivalues]
-       instead.
+    !!! warning "Deprecation warning"
+        This method is deprecated and will be replaced in 0.8.0 by the more
+        general implementation of
+        [compute_generic_semivalues][pydvl.value.semivalues.compute_generic_semivalues].
+        Use
+        [compute_shapley_semivalues][pydvl.value.semivalues.compute_shapley_semivalues],
+        [compute_banzhaf_semivalues][pydvl.value.semivalues.compute_banzhaf_semivalues],
+        or
+        [compute_beta_shapley_semivalues][pydvl.value.semivalues.compute_beta_shapley_semivalues]
+        instead.
 
     The modes supported with this interface are the following. For greater
     flexibility use
     [compute_generic_semivalues][pydvl.value.semivalues.compute_generic_semivalues]
     directly.
 
-    - [SemiValueMode.Shapley][pydvl.value.semivalues.SemiValueMode.Shapley]:
+    - [SemiValueMode.Shapley][pydvl.value.semivalues.SemiValueMode]:
       Shapley values.
-    - [SemiValueMode.BetaShapley][pydvl.value.semivalues.SemiValueMode.BetaShapley]:
+    - [SemiValueMode.BetaShapley][pydvl.value.semivalues.SemiValueMode]:
       Implements the Beta Shapley semi-value as introduced in [@kwon_beta_2022].
       Pass additional keyword arguments `alpha` and `beta` to set the
       parameters of the Beta distribution (both default to 1).
-    - [SemiValueMode.Banzhaf][SemiValueMode.Banzhaf]: Implements the Banzhaf
-      semi-value as introduced in [@wang_data_2022].
-
-    See [[data-valuation]] for an overview of valuation.
+    - [SemiValueMode.Banzhaf][pydvl.value.semivalues.SemiValueMode]: Implements
+      the Banzhaf semi-value as introduced in [@wang_data_2022].
 
     Args:
         u: Utility object with model, data, and scoring function.

--- a/src/pydvl/value/semivalues.py
+++ b/src/pydvl/value/semivalues.py
@@ -74,7 +74,7 @@ __all__ = [
     "beta_coefficient",
     "banzhaf_coefficient",
     "shapley_coefficient",
-    "semivalues",
+    "compute_generic_semivalues",
     "compute_semivalues",
     "SemiValueMode",
 ]
@@ -101,7 +101,7 @@ MarginalT = Tuple[IndexT, float]
 
 def _marginal(u: Utility, coefficient: SVCoefficient, sample: SampleT) -> MarginalT:
     """Computation of marginal utility. This is a helper function for
-    [semivalues()][pydvl.value.semivalues.semivalues].
+    [compute_generic_semivalues][pydvl.value.semivalues.compute_generic_semivalues].
 
     Args:
         u: Utility object with model, data, and scoring function.
@@ -123,7 +123,7 @@ def _marginal(u: Utility, coefficient: SVCoefficient, sample: SampleT) -> Margin
 #     deprecated_in="0.8.0",
 #     remove_in="0.9.0",
 # )
-def semivalues(
+def compute_generic_semivalues(
     sampler: PowersetSampler,
     u: Utility,
     coefficient: SVCoefficient,
@@ -248,10 +248,11 @@ def compute_shapley_semivalues(
 ) -> ValuationResult:
     """Computes Shapley values for a given utility function.
 
-    This is a convenience wrapper for :func:`semivalues` with the Shapley
-    coefficient. Use :func:`~pydvl.value.shapley.common.compute_shapley_values`
-    for a more flexible interface and additional methods, including Truncated
-    Monte Carlo.
+    This is a convenience wrapper for
+    [compute_generic_semivalues][pydvl.value.semivalues.compute_generic_semivalues]
+    with the Shapley coefficient. Use
+    [compute_shapley_values][pydvl.value.shapley.common.compute_shapley_values]
+    for a more flexible interface and additional methods, including TMCS.
 
     Args:
         u: Utility object with model, data, and scoring function.
@@ -266,7 +267,7 @@ def compute_shapley_semivalues(
     Returns:
         Object with the results.
     """
-    return semivalues(
+    return compute_generic_semivalues(
         sampler_t(u.data.indices),
         u,
         shapley_coefficient,
@@ -288,8 +289,9 @@ def compute_banzhaf_semivalues(
 ) -> ValuationResult:
     """Computes Banzhaf values for a given utility function.
 
-    This is a convenience wrapper for :func:`semivalues` with the Banzhaf
-    coefficient.
+    This is a convenience wrapper for
+    [compute_generic_semivalues][pydvl.value.semivalues.compute_generic_semivalues]
+    with the Banzhaf coefficient.
 
     Args:
         u: Utility object with model, data, and scoring function.
@@ -304,7 +306,7 @@ def compute_banzhaf_semivalues(
     Returns:
         Object with the results.
     """
-    return semivalues(
+    return compute_generic_semivalues(
         sampler_t(u.data.indices),
         u,
         banzhaf_coefficient,
@@ -328,8 +330,9 @@ def compute_beta_shapley_semivalues(
 ) -> ValuationResult:
     """Computes Beta Shapley values for a given utility function.
 
-    This is a convenience wrapper for :func:`semivalues` with the Beta Shapley
-    coefficient.
+    This is a convenience wrapper for
+    [compute_generic_semivalues][pydvl.value.semivalues.compute_generic_semivalues]
+    with the Beta Shapley coefficient.
 
     Args:
         u: Utility object with model, data, and scoring function.
@@ -344,7 +347,7 @@ def compute_beta_shapley_semivalues(
     Returns:
         Object with the results.
     """
-    return semivalues(
+    return compute_generic_semivalues(
         sampler_t(u.data.indices),
         u,
         beta_coefficient(alpha, beta),
@@ -380,7 +383,8 @@ def compute_semivalues(
 
     !!! Warning
        This method is deprecated and will be replaced in 0.8.0 by the more
-       general implementation of [semivalues][pydvl.value.semivalues.semivalues].
+       general implementation of
+       [compute_generic_semivalues][pydvl.value.semivalues.compute_generic_semivalues].
        Use
        [compute_shapley_semivalues][pydvl.value.semivalues.compute_shapley_semivalues],
        [compute_banzhaf_semivalues][pydvl.value.semivalues.compute_banzhaf_semivalues], or
@@ -388,7 +392,9 @@ def compute_semivalues(
        instead.
 
     The modes supported with this interface are the following. For greater
-    flexibility use [semivalues][pydvl.value.semivalues.semivalues] directly.
+    flexibility use
+    [compute_generic_semivalues][pydvl.value.semivalues.compute_generic_semivalues]
+    directly.
 
     - [SemiValueMode.Shapley][pydvl.value.semivalues.SemiValueMode.Shapley]:
       Shapley values.
@@ -410,7 +416,7 @@ def compute_semivalues(
             for a list.
         n_jobs: Number of parallel jobs to use.
         kwargs: Additional keyword arguments passed to
-            [semivalues()][pydvl.value.semivalues.semivalues].
+            [compute_generic_semivalues][pydvl.value.semivalues.compute_generic_semivalues].
 
     Returns:
         Object with the results.
@@ -427,4 +433,6 @@ def compute_semivalues(
     else:
         raise ValueError(f"Unknown mode {mode}")
     coefficient = cast(SVCoefficient, coefficient)
-    return semivalues(sampler_instance, u, coefficient, done, n_jobs=n_jobs, **kwargs)
+    return compute_generic_semivalues(
+        sampler_instance, u, coefficient, done, n_jobs=n_jobs, **kwargs
+    )

--- a/tests/value/test_semivalues.py
+++ b/tests/value/test_semivalues.py
@@ -17,7 +17,7 @@ from pydvl.value.semivalues import (
     SVCoefficient,
     banzhaf_coefficient,
     beta_coefficient,
-    semivalues,
+    compute_generic_semivalues,
     shapley_coefficient,
 )
 from pydvl.value.stopping import AbsoluteStandardError, MaxUpdates
@@ -47,7 +47,7 @@ def test_shapley(
 ):
     u, exact_values = analytic_shapley
     criterion = AbsoluteStandardError(0.02, 1.0) | MaxUpdates(2 ** (num_samples * 2))
-    values = semivalues(
+    values = compute_generic_semivalues(
         sampler(u.data.indices),
         u,
         coefficient,
@@ -77,7 +77,7 @@ def test_banzhaf(
     parallel_config: ParallelConfig,
 ):
     u, exact_values = analytic_banzhaf
-    values = semivalues(
+    values = compute_generic_semivalues(
         sampler(u.data.indices),
         u,
         banzhaf_coefficient,


### PR DESCRIPTION
<!--
Thanks for making a contribution! 
Please make sure you have read the contributing guide: 
https://github.com/appliedAI-Initiative/pyDVL/blob/develop/CONTRIBUTING.md
-->

### Description

This PR renames a method in semivalues.py in order to fix the problem with name clashing. It also fixes docstrings

### Changes

- Renamed the (somewhat internal) function `semivalues` to `compute_generic_semivalues` (yikes! 😱)
- Fixes some docstrings and formulas, now that I can see them 😮‍💨 

### Checklist

- [ ] Wrote Unit tests (if necessary)
- [x] Updated Documentation (if necessary)
- [x] Updated Changelog
- [ ] If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`
