### PR TITLE
Small docs fixes

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -92,6 +92,7 @@ jobs:
     name: Push Docs and maybe release Package to TestPyPI
     runs-on: ubuntu-latest
     needs: [docs, base-tests, torch-tests, notebook-tests]
+    if: ${{ github.ref == 'refs/heads/develop' }}
     concurrency:
       group: publish
     steps:
@@ -111,7 +112,6 @@ jobs:
           email: ${{ env.GITHUB_BOT_EMAIL }}
           username: ${{ env.GITHUB_BOT_USERNAME }}
       - name: Build and publish to TestPyPI
-        if: ${{ github.ref == 'refs/heads/develop' }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -17,6 +17,7 @@ env:
   GITHUB_BOT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
   PY_COLORS: 1
   MYPY_FORCE_COLOR: 1
+  PANDOC_VERSION: '3.1.6.2'
 
 jobs:
   code-quality:
@@ -55,7 +56,7 @@ jobs:
     - name: Install Pandoc
       uses: r-lib/actions/setup-pandoc@v2
       with:
-        pandoc-version: '3.1.6.2'
+        pandoc-version: ${{ env.PANDOC_VERSION }}
     - name: Build Docs
       run: mkdocs build
   base-tests:
@@ -103,6 +104,10 @@ jobs:
         uses: ./.github/actions/python
         with:
           python_version: 3.8
+      - name: Install Pandoc
+        uses: r-lib/actions/setup-pandoc@v2
+        with:
+          pandoc-version: ${{ env.PANDOC_VERSION }}
       - name: Deploy Docs
         uses: ./.github/actions/deploy-docs
         with:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ plugins:
             - https://pandas.pydata.org/docs/objects.inv
             - https://scikit-learn.org/stable/objects.inv
             - https://pytorch.org/docs/stable/objects.inv
+            - https://pymemcache.readthedocs.io/en/latest/objects.inv
           paths: [ src ]  # search packages in the src folder
           options:
             docstring_style: google

--- a/src/pydvl/influence/torch/torch_differentiable.py
+++ b/src/pydvl/influence/torch/torch_differentiable.py
@@ -205,11 +205,12 @@ class TorchTwiceDifferentiable(TwiceDifferentiable[torch.Tensor]):
 @dataclass
 class LowRankProductRepresentation:
     r"""
-    Representation of a low rank product of the form \(H = V D V^T\), where D is a diagonal matrix and V is orthogonal.
+    Representation of a low rank product of the form \(H = V D V^T\),
+    where D is a diagonal matrix and V is orthogonal.
 
     Args:
-        eigen_vals (tensor or array): Diagonal of D.
-        projections (tensor or matrix): The matrix V.
+        eigen_vals: Diagonal of D.
+        projections: The matrix V.
     """
 
     eigen_vals: torch.Tensor
@@ -276,7 +277,7 @@ def lanzcos_low_rank_hessian_approx(
             not provided, it defaults to \( 10 \cdot \text{model.num_parameters}\).
         device: The device to use for executing the hessian vector product.
         eigen_computation_on_gpu: If True, tries to execute the eigen pair
-            approximation on the provided device via `cupy <https://cupy.dev/>`_
+            approximation on the provided device via [cupy](https://cupy.dev/)
             implementation. Ensure that either your model is small enough, or you
             use a small rank_estimate to fit your device's memory. If False, the
             eigen pair approximation is executed on the CPU with scipy's wrapper to
@@ -608,7 +609,8 @@ def solve_cg(
         maxiter: Maximum number of iterations. If None, defaults to 10*len(b).
 
     Returns:
-        Instance of [InverseHvpResult], with a vector x, solution of \(Ax=b\), and a dictionary containing
+        Instance of [InverseHvpResult][pydvl.influence.twice_differentiable.InverseHvpResult],
+            with a vector x, solution of \(Ax=b\), and a dictionary containing
             information about the convergence of CG.
     """
 

--- a/src/pydvl/influence/torch/util.py
+++ b/src/pydvl/influence/torch/util.py
@@ -6,10 +6,26 @@ import torch
 
 logger = logging.getLogger(__name__)
 
+__all__ = [
+    "to_model_device",
+    "flatten_tensors_to_vector",
+    "reshape_vector_to_tensors",
+    "TorchTensorContainerType",
+    "align_structure",
+    "as_tensor",
+]
+
 
 def to_model_device(x: torch.Tensor, model: torch.nn.Module) -> torch.Tensor:
     """
     Returns the tensor `x` moved to the device of the `model`, if device of model is set
+
+    Args:
+        x: The tensor to be moved to the device of the model.
+        model: The model whose device will be used to move the tensor.
+
+    Returns:
+        The tensor `x` moved to the device of the `model`, if device of model is set.
     """
     if hasattr(model, "device"):
         return x.to(model.device)
@@ -81,6 +97,7 @@ TorchTensorContainerType = TypeVar(
     Tuple[torch.Tensor, ...],
     Dict[str, torch.Tensor],
 )
+"""Type variable for a PyTorch tensor or a container thereof."""
 
 
 def align_structure(

--- a/src/pydvl/influence/twice_differentiable.py
+++ b/src/pydvl/influence/twice_differentiable.py
@@ -23,8 +23,13 @@ __all__ = [
 ]
 
 TensorType = TypeVar("TensorType", bound=Sequence)
+"""Type variable for tensors, i.e. sequences of numbers"""
+
 ModelType = TypeVar("ModelType", bound="TwiceDifferentiable")
+"""Type variable for twice differentiable models"""
+
 DataLoaderType = TypeVar("DataLoaderType", bound=Iterable)
+"""Type variable for data loaders"""
 
 
 @dataclass(frozen=True)
@@ -94,7 +99,7 @@ class TwiceDifferentiable(ABC, Generic[TensorType]):
 
         Returns:
             A tensor representing the Hessian of the model, i.e. the second derivative
-            with respect to the model parameters.
+                with respect to the model parameters.
         """
 
         pass
@@ -123,7 +128,7 @@ class TwiceDifferentiable(ABC, Generic[TensorType]):
 
         Returns:
             A matrix representing the implicit matrix-vector product of the model along the given directions.
-            Output shape is [DxM], where \(M\) is the number of elements of `backprop_on`.
+                Output shape is [DxM], where \(M\) is the number of elements of `backprop_on`.
         """
 
 
@@ -159,7 +164,7 @@ class TensorUtilities(Generic[TensorType, ModelType], ABC):
     @staticmethod
     @abstractmethod
     def einsum(equation, *operands) -> TensorType:
-        """Sums the product of the elements of the input :attr:`operands` along dimensions specified using a notation
+        """Sums the product of the elements of the input `operands` along dimensions specified using a notation
         based on the Einstein summation convention.
         """
 

--- a/src/pydvl/reporting/plots.py
+++ b/src/pydvl/reporting/plots.py
@@ -21,12 +21,12 @@ def shaded_mean_std(
     ax: Optional[Axes] = None,
     **kwargs,
 ) -> Axes:
-    """The usual mean +- std deviation plot to aggregate runs of experiments.
+    """The usual mean \(\pm\) std deviation plot to aggregate runs of experiments.
 
     Args:
         data: axis 0 is to be aggregated on (e.g. runs) and axis 1 is the
             data for each run.
-        abscissa: values for the x axis. Leave empty to use increasing integers.
+        abscissa: values for the x-axis. Leave empty to use increasing integers.
         num_std: number of standard deviations to shade around the mean.
         mean_color: color for the mean
         shade_color: color for the shaded region

--- a/src/pydvl/utils/caching.py
+++ b/src/pydvl/utils/caching.py
@@ -34,7 +34,6 @@ default_config = dict(
    serde=serde.PickleSerde(pickle_version=PICKLE_VERSION)
 )
 ```
-.. _caching stochastic functions:
 
 # Usage with stochastic functions
 
@@ -129,7 +128,13 @@ class CacheStats:
 
 
 def serialize(x: Any) -> bytes:
-    """Serialize an object to bytes."""
+    """Serialize an object to bytes.
+    Args:
+        x: object to serialize.
+
+    Returns:
+        serialized object.
+    """
     pickled_output = BytesIO()
     pickler = Pickler(pickled_output, PICKLE_VERSION)
     pickler.dump(x)
@@ -169,8 +174,8 @@ def memcached(
         ```
 
     Args:
-        client_config: configuration for `pymemcache's Client()
-            <https://pymemcache.readthedocs.io/en/stable/apidoc/pymemcache.client.base.html>`_.
+        client_config: configuration for pymemcache's
+            [Client][pymemcache.client.base.Client].
             Will be merged on top of the default configuration (see below).
         time_threshold: computations taking less time than this many seconds are
             not cached.
@@ -188,7 +193,7 @@ def memcached(
         ignore_args: Do not take these keyword arguments into account when
             hashing the wrapped function for usage as key in memcached. This allows
             sharing the cache among different jobs for the same experiment run if
-            the callable happens to have "nuisance" parameters like "job_id" which
+            the callable happens to have "nuisance" parameters like `job_id` which
             do not affect the result of the computation.
 
     Returns:

--- a/src/pydvl/utils/dataset.py
+++ b/src/pydvl/utils/dataset.py
@@ -257,15 +257,23 @@ class Dataset:
     ) -> "Dataset":
         """Constructs a [Dataset][pydvl.utils.Dataset] object from a
         [sklearn.utils.Bunch][sklearn.utils.Bunch], as returned by the `load_*`
-        functions in [sklearn toy datasets](https://scikit-learn.org/stable/datasets/toy_dataset.html).
+        functions in [scikit-learn toy datasets](https://scikit-learn.org/stable/datasets/toy_dataset.html).
+
+        ??? Example
+            ```pycon
+            >>> from pydvl.utils import Dataset
+            >>> from sklearn.datasets import load_boston
+            >>> dataset = Dataset.from_sklearn(load_boston())
+            ```
 
         Args:
-            data: sklearn dataset. The following attributes are supported
-                - `data`: covariates [required]
-                - `target`: target variables (labels) [required]
-                - `feature_names`: the feature names
-                - `target_names`: the target names
-                - `DESCR`: a description
+            data: scikit-learn Bunch object. The following attributes are supported:
+
+                - `data`: covariates.
+                - `target`: target variables (labels).
+                - `feature_names` (**optional**): the feature names.
+                - `target_names` (**optional**): the target names.
+                - `DESCR` (**optional**): a description.
             train_size: size of the training dataset. Used in `train_test_split`
             random_state: seed for train / test split
             stratify_by_target: If `True`, data is split in a stratified
@@ -310,6 +318,14 @@ class Dataset:
     ) -> "Dataset":
         """Constructs a [Dataset][pydvl.utils.Dataset] object from X and y numpy arrays  as
         returned by the `make_*` functions in [sklearn generated datasets](https://scikit-learn.org/stable/datasets/sample_generators.html).
+
+        ??? Example
+            ```pycon
+            >>> from pydvl.utils import Dataset
+            >>> from sklearn.datasets import make_regression
+            >>> X, y = make_regression()
+            >>> dataset = Dataset.from_arrays(X, y)
+            ```
 
         Args:
             X: numpy array of shape (n_samples, n_features)
@@ -456,16 +472,26 @@ class GroupedDataset(Dataset):
     ) -> "GroupedDataset":
         """Constructs a [GroupedDataset][pydvl.utils.GroupedDataset] object from a
         [sklearn.utils.Bunch][sklearn.utils.Bunch] as returned by the `load_*` functions in
-        [sklearn toy datasets](https://scikit-learn.org/stable/datasets/toy_dataset.html) and groups
+        [scikit-learn toy datasets](https://scikit-learn.org/stable/datasets/toy_dataset.html) and groups
         it.
 
+        ??? Example
+            ```pycon
+            >>> from sklearn.datasets import load_iris
+            >>> from pydvl.utils import GroupedDataset
+            >>> iris = load_iris()
+            >>> data_groups = iris.data[:, 0] // 0.5
+            >>> dataset = GroupedDataset.from_sklearn(iris, data_groups=data_groups)
+            ```
+
         Args:
-            data: sklearn dataset. The following attributes are supported
-                - `data`: covariates [required]
-                - `target`: target variables (labels) [required]
-                - `feature_names`: the feature names
-                - `target_names`: the target names
-                - `DESCR`: a description
+            data: scikit-learn Bunch object. The following attributes are supported:
+
+                - `data`: covariates.
+                - `target`: target variables (labels).
+                - `feature_names` (**optional**): the feature names.
+                - `target_names` (**optional**): the target names.
+                - `DESCR` (**optional**): a description.
             train_size: size of the training dataset. Used in `train_test_split`.
             random_state: seed for train / test split.
             stratify_by_target: If `True`, data is split in a stratified
@@ -512,7 +538,23 @@ class GroupedDataset(Dataset):
     ) -> "Dataset":
         """Constructs a [GroupedDataset][pydvl.utils.GroupedDataset] object from X and y numpy arrays
         as returned by the `make_*` functions in
-        [sklearn generated datasets](https://scikit-learn.org/stable/datasets/sample_generators.html).
+        [scikit-learn generated datasets](https://scikit-learn.org/stable/datasets/sample_generators.html).
+
+        ??? Example
+            ```pycon
+            >>> from sklearn.datasets import make_classification
+            >>> from pydvl.utils import GroupedDataset
+            >>> X, y = make_classification(
+            ...     n_samples=100,
+            ...     n_features=4,
+            ...     n_informative=2,
+            ...     n_redundant=0,
+            ...     random_state=0,
+            ...     shuffle=False
+            ... )
+            >>> data_groups = X[:, 0] // 0.5
+            >>> dataset = GroupedDataset.from_arrays(X, y, data_groups=data_groups)
+            ```
 
         Args:
             X: array of shape (n_samples, n_features)
@@ -560,6 +602,17 @@ class GroupedDataset(Dataset):
     ) -> "GroupedDataset":
         """Creates a [GroupedDataset][pydvl.utils.GroupedDataset] object from the data a
         [Dataset][pydvl.utils.Dataset] object and a mapping of data groups.
+
+        ??? Example
+            ```pycon
+            >>> import numpy as np
+            >>> from pydvl.utils import Dataset, GroupedDataset
+            >>> dataset = Dataset.from_arrays(
+            ...     X=np.asarray([[1, 2], [3, 4], [5, 6], [7, 8]]),
+            ...     y=np.asarray([0, 1, 0, 1]),
+            ... )
+            >>> dataset = GroupedDataset.from_dataset(dataset, data_groups=[0, 0, 1, 1])
+            ```
 
         Args:
             dataset: The original data.

--- a/src/pydvl/utils/parallel/futures/ray.py
+++ b/src/pydvl/utils/parallel/futures/ray.py
@@ -114,7 +114,8 @@ class RayExecutor(Executor):
         Returns:
             A Future representing the given call.
 
-        :raises RuntimeError: If a task is submitted after the executor has been shut down.
+        Raises:
+            RuntimeError: If a task is submitted after the executor has been shut down.
         """
         with self._shutdown_lock:
             logger.debug("executor acquired shutdown lock")
@@ -141,16 +142,18 @@ class RayExecutor(Executor):
     ) -> None:
         """Clean up the resources associated with the Executor.
 
-        This method tries to mimic the behaviour of :meth:`Executor.shutdown`
+        This method tries to mimic the behaviour of
+        [Executor.shutdown][concurrent.futures.Executor.shutdown]
         while allowing one more value for ``cancel_futures`` which instructs it
-        to use the :class:`CancellationPolicy` defined upon construction.
+        to use the [CancellationPolicy][pydvl.utils.parallel.backend.CancellationPolicy]
+        defined upon construction.
 
-        :param wait: Whether to wait for pending futures to finish.
-        :param cancel_futures: Overrides the executor's default policy for
-            cancelling futures on exit. If ``True``, all pending futures are
-            cancelled, and if ``False``, no futures are cancelled. If ``None``
-            (default), the executor's policy set at initialization is used.
-        :return:
+        Args:
+            wait: Whether to wait for pending futures to finish.
+            cancel_futures: Overrides the executor's default policy for
+                cancelling futures on exit. If ``True``, all pending futures are
+                cancelled, and if ``False``, no futures are cancelled. If ``None``
+                (default), the executor's policy set at initialization is used.
         """
         logger.debug("executor shutting down")
         with self._shutdown_lock:
@@ -198,7 +201,7 @@ class RayExecutor(Executor):
 
 
 class _WorkItem:
-    """Inspired by code from: concurrent.futures.thread"""
+    """Inspired by code from: [concurrent.futures.thread][]"""
 
     def __init__(
         self,

--- a/src/pydvl/utils/utility.py
+++ b/src/pydvl/utils/utility.py
@@ -15,6 +15,12 @@ of the model to compute the score.
 This module also contains Utility classes for toy games that are used
 for testing and for demonstration purposes.
 
+## References:
+
+[^1]: <a name="wang_improving_2022"></a>Wang, T., Yang, Y. and Jia, R., 2021.
+    [Improving cooperative game theory-based data valuation via data utility learning](https://arxiv.org/abs/2107.06336).
+    arXiv preprint arXiv:2107.06336.
+
 """
 import logging
 import warnings
@@ -74,9 +80,10 @@ class Utility:
             ranges.
 
     Args:
-        model: Any supervised model. Typical choices can be found at
-                https://scikit-learn.org/stable/supervised_learning.html
-        data: Dataset or GroupedDataset instance.
+        model: Any supervised model. Typical choices can be found in the
+            [sci-kit learn documentation][https://scikit-learn.org/stable/supervised_learning.html].
+        data: [Dataset][pydvl.utils.dataset.Dataset]
+            or [GroupedDataset][pydvl.utils.dataset.GroupedDataset] instance.
         scorer: A scoring object. If None, the `score()` method of the model
             will be used. See [score][pydvl.utils.score] for ways to create
             and compose scorers, in particular how to set default values and ranges.
@@ -266,7 +273,8 @@ class Utility:
 
 
 class DataUtilityLearning:
-    """Implementation of Data Utility Learning [@wang_improving_2022].
+    """Implementation of Data Utility Learning
+    (Wang et al., 2022)<sup><a href="#wang_improving_2022">1</a></sup>.
 
     This object wraps a [Utility][pydvl.utils.utility.Utility] and delegates
     calls to it, up until a given budget (number of iterations). Every tuple


### PR DESCRIPTION
### Description

This PR fixes a few things in the documentation that I noticed.

### Changes

- Added pymemcache inventory.
- Fixed links and references in multiple docstrings.
- Added reference for Data Utility Learning.
- Added examples to `Dataset` and `GroupedDataset` constructor class methods.
- Fixed remaining rest syntax leftovers.
- Fix deploy docs condition on CI.
- Install pandoc before deploy docs step on CI.

### Checklist

- [ ] Wrote Unit tests (if necessary)
- [ ] Updated Documentation (if necessary)
- [ ] Updated Changelog
- [ ] If notebooks were added/changed, added boilerplate cells are tagged with `"nbsphinx":"hidden"`
